### PR TITLE
Fix AlmaLinux OS 9.3 GNOME build

### DIFF
--- a/kickstarts/almalinux-9-live-gnome.ks
+++ b/kickstarts/almalinux-9-live-gnome.ks
@@ -1484,11 +1484,11 @@ qemu-kvm-block-rbd
 qemu-kvm-common
 qemu-kvm-core
 qemu-kvm-device-display-virtio-gpu
-qemu-kvm-device-display-virtio-gpu-gl
+# qemu-kvm-device-display-virtio-gpu-gl # Not available on 9.3
 qemu-kvm-device-display-virtio-gpu-pci
-qemu-kvm-device-display-virtio-gpu-pci-gl
+# qemu-kvm-device-display-virtio-gpu-pci-gl # Not available on 9.3
 qemu-kvm-device-display-virtio-vga
-qemu-kvm-device-display-virtio-vga-gl
+# qemu-kvm-device-display-virtio-vga-gl # Not available on 9.3
 qemu-kvm-device-usb-host
 qemu-kvm-device-usb-redirect
 qemu-kvm-docs


### PR DESCRIPTION
The GNOME build for 9.3 fails becaus of these packages are not available on AlmaLinux OS 9.3 repositories:
- qemu-kvm-device-display-virtio-gpu-gl
- qemu-kvm-device-display-virtio-gpu-pci-gl
- qemu-kvm-device-display-virtio-vga-gl

Remove them from the list of packages to be installed.