### PR TITLE
Remove openvpn workaround for MATE

### DIFF
--- a/kickstarts/almalinux-9-live-gnome-mini.ks
+++ b/kickstarts/almalinux-9-live-gnome-mini.ks
@@ -15,9 +15,9 @@ firewall --enabled --service=mdns
 # Repos
 url --url=https://atl.mirrors.knownhost.com/almalinux/9/BaseOS/$basearch/os/
 repo --name="appstream" --baseurl=https://atl.mirrors.knownhost.com/almalinux/9/AppStream/$basearch/os/
-repo --name="crb" --baseurl=https://atl.mirrors.knownhost.com/almalinux/9/CRB/$basearch/os/
 repo --name="extras" --baseurl=https://atl.mirrors.knownhost.com/almalinux/9/extras/$basearch/os/
-repo --name=epel --baseurl="https://dl.fedoraproject.org/pub/epel/9/Everything/$basearch/"
+repo --name="crb" --baseurl=https://atl.mirrors.knownhost.com/almalinux/9/CRB/$basearch/os/
+repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/9/Everything/$basearch/
 
 
 # Network information

--- a/kickstarts/almalinux-9-live-gnome.ks
+++ b/kickstarts/almalinux-9-live-gnome.ks
@@ -15,9 +15,9 @@ firewall --enabled --service=mdns
 # Repos
 url --url=https://atl.mirrors.knownhost.com/almalinux/9/BaseOS/$basearch/os/
 repo --name="appstream" --baseurl=https://atl.mirrors.knownhost.com/almalinux/9/AppStream/$basearch/os/
-repo --name="crb" --baseurl=https://atl.mirrors.knownhost.com/almalinux/9/CRB/$basearch/os/
 repo --name="extras" --baseurl=https://atl.mirrors.knownhost.com/almalinux/9/extras/$basearch/os/
-repo --name=epel --baseurl="https://dl.fedoraproject.org/pub/epel/9/Everything/$basearch/"
+repo --name="crb" --baseurl=https://atl.mirrors.knownhost.com/almalinux/9/CRB/$basearch/os/
+repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/9/Everything/$basearch/
 
 # Network information
 network --activate --bootproto=dhcp --device=link --onboot=on

--- a/kickstarts/almalinux-9-live-mate.ks
+++ b/kickstarts/almalinux-9-live-mate.ks
@@ -17,10 +17,9 @@ network  --bootproto=dhcp --device=link --activate
 # Repos
 url --url=https://atl.mirrors.knownhost.com/almalinux/9/BaseOS/$basearch/os/
 repo --name="appstream" --baseurl=https://atl.mirrors.knownhost.com/almalinux/9/AppStream/$basearch/os/
-repo --name="crb" --baseurl=https://atl.mirrors.knownhost.com/almalinux/9/CRB/$basearch/os/
 repo --name="extras" --baseurl=https://atl.mirrors.knownhost.com/almalinux/9/extras/$basearch/os/
+repo --name="crb" --baseurl=https://atl.mirrors.knownhost.com/almalinux/9/CRB/$basearch/os/
 repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/9/Everything/$basearch/
-repo --name="openvpn-test" --baseurl=https://build.almalinux.org/pulp/content/builds/AlmaLinux-9-x86_64-7291-br/ --cost=100
 
 # Firewall configuration
 firewall --enabled --service=mdns

--- a/kickstarts/almalinux-9-live-xfce.ks
+++ b/kickstarts/almalinux-9-live-xfce.ks
@@ -17,8 +17,8 @@ network  --bootproto=dhcp --device=link --activate
 # Repos
 url --url=https://atl.mirrors.knownhost.com/almalinux/9/BaseOS/$basearch/os/
 repo --name="appstream" --baseurl=https://atl.mirrors.knownhost.com/almalinux/9/AppStream/$basearch/os/
-repo --name="crb" --baseurl=https://atl.mirrors.knownhost.com/almalinux/9/CRB/$basearch/os/
 repo --name="extras" --baseurl=https://atl.mirrors.knownhost.com/almalinux/9/extras/$basearch/os/
+repo --name="crb" --baseurl=https://atl.mirrors.knownhost.com/almalinux/9/CRB/$basearch/os/
 repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/9/Everything/$basearch/
 
 # Firewall configuration


### PR DESCRIPTION
Since the 2.5.9-2.el9 version of openvpn package on EPEL includes our proposed fix, we can switch back from our build to EPEL one.