### PR TITLE
Fix Anaconda welcome screen on AlmaLinux OS 9

### DIFF
--- a/kickstarts/almalinux-9-live-gnome-mini.ks
+++ b/kickstarts/almalinux-9-live-gnome-mini.ks
@@ -355,10 +355,10 @@ favorite-apps=['firefox.desktop', 'evolution.desktop', 'rhythmbox.desktop', 'sho
 FOE
 
   # Make the welcome screen show up
-  if [ -f /usr/share/anaconda/gnome/rhel-welcome.desktop ]; then
+  if [ -f /usr/share/anaconda/gnome/fedora-welcome.desktop ]; then
     mkdir -p ~liveuser/.config/autostart
-    cp /usr/share/anaconda/gnome/rhel-welcome.desktop /usr/share/applications/
-    cp /usr/share/anaconda/gnome/rhel-welcome.desktop ~liveuser/.config/autostart/
+    cp /usr/share/anaconda/gnome/fedora-welcome.desktop /usr/share/applications/
+    cp /usr/share/anaconda/gnome/fedora-welcome.desktop ~liveuser/.config/autostart/
   fi
 
   # Copy Anaconda branding in place

--- a/kickstarts/almalinux-9-live-gnome.ks
+++ b/kickstarts/almalinux-9-live-gnome.ks
@@ -353,12 +353,12 @@ if [ -f /usr/share/applications/liveinst.desktop ]; then
 favorite-apps=['firefox.desktop', 'evolution.desktop', 'rhythmbox.desktop', 'shotwell.desktop', 'org.gnome.Nautilus.desktop', 'anaconda.desktop']
 FOE
 
-  # Make the welcome screen show up
-  if [ -f /usr/share/anaconda/gnome/rhel-welcome.desktop ]; then
-    mkdir -p ~liveuser/.config/autostart
-    cp /usr/share/anaconda/gnome/rhel-welcome.desktop /usr/share/applications/
-    cp /usr/share/anaconda/gnome/rhel-welcome.desktop ~liveuser/.config/autostart/
-  fi
+# Make the welcome screen show up
+if [ -f /usr/share/anaconda/gnome/fedora-welcome.desktop ]; then
+  mkdir -p ~liveuser/.config/autostart
+  cp /usr/share/anaconda/gnome/fedora-welcome.desktop /usr/share/applications/
+  cp /usr/share/anaconda/gnome/fedora-welcome.desktop ~liveuser/.config/autostart/
+fi
 
   # Copy Anaconda branding in place
   if [ -d /usr/share/lorax/product/usr/share/anaconda ]; then

--- a/kickstarts/almalinux-9-live-kde.ks
+++ b/kickstarts/almalinux-9-live-kde.ks
@@ -420,28 +420,20 @@ chmod +x /usr/share/applications/liveinst.desktop
 mkdir -p /home/liveuser/Desktop /home/liveuser/.config/autostart /home/liveuser/.cache/thumbnails
 cp -a /usr/share/applications/liveinst.desktop /home/liveuser/Desktop/
 
-# Make the welcome screen show up EL8
-  if [ -f /usr/share/anaconda/gnome/rhel-welcome.desktop ]; then
-    # fix log warning in line 152
-    sed -i 's/init(null, null)/init(null)/' /usr/share/anaconda/gnome/rhel-welcome
-    cp /usr/share/anaconda/gnome/rhel-welcome.desktop /usr/share/applications/
-    cp /usr/share/anaconda/gnome/rhel-welcome.desktop ~liveuser/.config/autostart/
-  fi
+# Make the welcome screen show up
+if [ -f /usr/share/anaconda/gnome/fedora-welcome.desktop ]; then
+  mkdir -p ~liveuser/.config/autostart
+  cp /usr/share/anaconda/gnome/fedora-welcome.desktop /usr/share/applications/
+  cp /usr/share/anaconda/gnome/fedora-welcome.desktop ~liveuser/.config/autostart/
+fi
 
-  # Make the welcome screen show up EL9
-  if [ -f /usr/share/anaconda/gnome/fedora-welcome.desktop ]; then
-    # fix log warning in line 152
-    sed -i 's/init(null, null)/init(null)/' /usr/share/anaconda/gnome/fedora-welcome
-    cp /usr/share/anaconda/gnome/fedora-welcome.desktop /usr/share/applications/
-    cp /usr/share/anaconda/gnome/fedora-welcome.desktop ~liveuser/.config/autostart/
-  fi
-  # KDE live install popup not finding the second icon from current location, copy to different location to enable it
-  cp /usr/share/icons/hicolor/scalable/apps/org.fedoraproject.AnacondaInstaller.svg /usr/share/icons/hicolor/48x48/apps/
+# KDE live install popup not finding the second icon from current location, copy to different location to enable it
+cp /usr/share/icons/hicolor/scalable/apps/org.fedoraproject.AnacondaInstaller.svg /usr/share/icons/hicolor/48x48/apps/
 
-  # Copy Anaconda branding in place
-  if [ -d /usr/share/lorax/product/usr/share/anaconda ]; then
-    cp -a /usr/share/lorax/product/* /
-  fi
+# Copy Anaconda branding in place
+if [ -d /usr/share/lorax/product/usr/share/anaconda ]; then
+  cp -a /usr/share/lorax/product/* /
+fi
 
 # Set akonadi backend
 mkdir -p /home/liveuser/.config/akonadi

--- a/kickstarts/almalinux-9-live-mate.ks
+++ b/kickstarts/almalinux-9-live-mate.ks
@@ -370,17 +370,16 @@ if [ -f /usr/share/applications/liveinst.desktop ]; then
 favorite-apps=['firefox.desktop', 'evolution.desktop', 'rhythmbox.desktop', 'shotwell.desktop', 'org.gnome.Nautilus.desktop', 'anaconda.desktop']
 FOE
 
-  # Make the welcome screen show up
-  if [ -f /usr/share/anaconda/gnome/rhel-welcome.desktop ]; then
-    mkdir -p ~liveuser/.config/autostart
-    cp /usr/share/anaconda/gnome/rhel-welcome.desktop /usr/share/applications/
-    cp /usr/share/anaconda/gnome/rhel-welcome.desktop ~liveuser/.config/autostart/
-  fi
+# Make the welcome screen show up
+if [ -f /usr/share/anaconda/gnome/fedora-welcome.desktop ]; then
+  mkdir -p ~liveuser/.config/autostart
+  cp /usr/share/anaconda/gnome/fedora-welcome.desktop /usr/share/applications/
+  cp /usr/share/anaconda/gnome/fedora-welcome.desktop ~liveuser/.config/autostart/
+fi
 
-  # Copy Anaconda branding in place
-  if [ -d /usr/share/lorax/product/usr/share/anaconda ]; then
-    cp -a /usr/share/lorax/product/* /
-  fi
+# Copy Anaconda branding in place
+if [ -d /usr/share/lorax/product/usr/share/anaconda ]; then
+  cp -a /usr/share/lorax/product/* /
 fi
 
 # rebuild schema cache with any overrides we installed

--- a/kickstarts/almalinux-9-live-xfce.ks
+++ b/kickstarts/almalinux-9-live-xfce.ks
@@ -376,24 +376,12 @@ PROFILE_EOF
   # need to move it to anaconda.desktop to make shell happy TODO: Is reuired for XFCE?
   mv /usr/share/applications/liveinst.desktop /usr/share/applications/anaconda.desktop
 
-  # Make the welcome screen show up EL8
-  if [ -f /usr/share/anaconda/gnome/rhel-welcome.desktop ]; then
-    mkdir -p ~liveuser/.config/autostart
-    # fix log warning in line 152
-    sed -i 's/init(null, null)/init(null)/' /usr/share/anaconda/gnome/rhel-welcome
-    sed -i 's/^#User=.*/User=liveuser/' /etc/sddm.conf
-    cp /usr/share/anaconda/gnome/rhel-welcome.desktop /usr/share/applications/
-    cp /usr/share/anaconda/gnome/rhel-welcome.desktop ~liveuser/.config/autostart/
-  fi
-
-  # Make the welcome screen show up EL9
-  if [ -f /usr/share/anaconda/gnome/fedora-welcome.desktop ]; then
-    mkdir -p ~liveuser/.config/autostart
-    # fix log warning in line 152
-    sed -i 's/init(null, null)/init(null)/' /usr/share/anaconda/gnome/fedora-welcome
-    cp /usr/share/anaconda/gnome/fedora-welcome.desktop /usr/share/applications/
-    cp /usr/share/anaconda/gnome/fedora-welcome.desktop ~liveuser/.config/autostart/
-  fi
+# Make the welcome screen show up
+if [ -f /usr/share/anaconda/gnome/fedora-welcome.desktop ]; then
+  mkdir -p ~liveuser/.config/autostart
+  cp /usr/share/anaconda/gnome/fedora-welcome.desktop /usr/share/applications/
+  cp /usr/share/anaconda/gnome/fedora-welcome.desktop ~liveuser/.config/autostart/
+fi
 
   # Copy Anaconda branding in place
   if [ -d /usr/share/lorax/product/usr/share/anaconda ]; then


### PR DESCRIPTION
Unlike the EL8, the EL9 uses fedora-welcome instead of rhel-welcome.