### PR TITLE
Don't install kdepim-addons on AlmaLinux OS 9.3

### DIFF
--- a/kickstarts/almalinux-9-live-kde.ks
+++ b/kickstarts/almalinux-9-live-kde.ks
@@ -879,7 +879,7 @@ kde-settings-pulseaudio
 kdecoration
 kdegraphics-mobipocket
 kdegraphics-thumbnailers
-kdepim-addons
+# kdepim-addons # Removed to fix a dependency issue on AlmaLinux OS 9.3
 kdepim-runtime
 kdepim-runtime-libs
 kdeplasma-addons


### PR DESCRIPTION
Do not install the kdepim-addons package because of a dependency issue on AlmaLinux OS 9.3 builds.