### PR TITLE
AlmaLinux Kitten 10 support

### DIFF
--- a/.github/workflows/build-media.yml
+++ b/.github/workflows/build-media.yml
@@ -37,11 +37,17 @@ on:
       version_major:
         description: 'AlmaLinux major version'
         required: true
-        default: '9'
+        default: '10-kitten'
         type: choice
         options:
+          - 10-kitten
           - 9
           - 8
+
+      iteration:
+        description: 'Kitten 10 build iteration'
+        required: true
+        default: '0'
 
       store_as_artifact:
         description: "Store ISO to the workflow Artifacts"
@@ -63,65 +69,123 @@ on:
 
 jobs:
   build-media:
-    name: AlmaLinux ${{ inputs.version_major }} ${{ matrix.image_types }}
+    name: ${{ matrix.release_variant }} ${{ matrix.image_types }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         # Set image types matrix based on boolean inputs.* with true value
         image_types: ${{ fromJSON(format('["{0}", "{1}", "{2}", "{3}", "{4}"]', ( inputs.GNOME && 'GNOME' ), ( inputs.GNOME-Mini && 'GNOME-Mini' ), ( inputs.KDE && 'KDE' ), ( inputs.MATE && 'MATE' ), ( inputs.XFCE && 'XFCE' ) )) }}
+        release_variant: ${{ fromJSON(format('["{0}"]', ( inputs.version_major == '10-kitten' && '10-kitten", "10-kitten-x86_64_v2' || inputs.version_major ) )) }}
         exclude:
           - image_types: 'false'
+          - release_variant: '10-kitten-x86_64_v2'
+            image_types: 'KDE'
+          - release_variant: '10-kitten-x86_64_v2'
+            image_types: 'MATE'
+          - release_variant: '10-kitten-x86_64_v2'
+            image_types: 'XFCE'
+          # TODO: these excludes need to be later removed
+          - release_variant: '10-kitten'
+            image_types: 'KDE'
+          - release_variant: '10-kitten'
+            image_types: 'MATE'
+          - release_variant: '10-kitten'
+            image_types: 'XFCE'
 
     steps:
 
     - uses: actions/checkout@v4
       name: Checkout ${{ github.action_repository }}
 
-    - name: Prepare AlmaLinux Minor version number
+    - name: Prepare envirounment variables
       run: |
-        case ${{ inputs.version_major }} in
-        8)
-            version_minor="10" ;;
-        9)
-            version_minor="4"  ;;
-        10)
-            version_minor="0" ;;
-        *)
+        # date stamp, YYYYMMDD
+        date_stamp=$(date -u '+%Y%m%d')
+
+        # Various environment variables
+        code_name_var=                                            # For the "AlmaLinux OS" string, empty or ' Kitten'
+        livemedia_creator_opts=                                   # livemedia-creator additional option(s)
+        arch=x86_64                                               # Arch, 'x86_64' or 'x86_64_v2'
+        dnf_crb_repo="CRB"                                        # YUM repository to enable, 'CRB' or 'PowerTools'
+        image_type=${{ matrix.image_types }}
+        need_pkgs="lorax lorax-templates-almalinux anaconda zstd"
+        vm_box='almalinux/${{ inputs.version_major }}'            # Vagrant image name, like 'almalinux/8', ...
+
+        case ${{ matrix.release_variant }} in
+          8)
+            version_minor=".10"
+            releasever=${{ inputs.version_major }}${version_minor}
+            results_name="AlmaLinux-${releasever}-${arch}-Live-${{ matrix.image_types }}"
+            volid="AlmaLinux-${releasever//./_}-${arch}-Live"
+            kickstart="almalinux-${{ inputs.version_major }}-live-${image_type,,}.ks"
+            livemedia_creator_opts='--anaconda-arg="--product AlmaLinux"'
+            dnf_crb_repo="PowerTools"
+            ;;
+          9)
+            version_minor=".4"
+            releasever=${{ inputs.version_major }}${version_minor}
+            results_name="AlmaLinux-${releasever}-${arch}-Live-${{ matrix.image_types }}"
+            volid="AlmaLinux-${releasever//./_}-${arch}-Live"
+            kickstart="almalinux-${{ inputs.version_major }}-live-${image_type,,}.ks"
+            need_pkgs="${need_pkgs} libblockdev-nvme"
+            ;;
+          10)
+            version_minor=".0"
+            releasever=${{ inputs.version_major }}${version_minor}
+            results_name="AlmaLinux-${releasever}-${arch}-Live-${{ matrix.image_types }}"
+            volid="AlmaLinux-${releasever//./_}-${arch}"
+            kickstart="almalinux-${{ inputs.version_major }}-live-${image_type,,}.ks"
+            need_pkgs="${need_pkgs} libblockdev-nvme"
+            ;;
+          10-kitten)
+            version_minor=
+            releasever=10
+            code_name_var=" Kitten"
+            results_name="AlmaLinux-Kitten-10-${date_stamp}.${{ inputs.iteration }}-${arch}-Live-${{ matrix.image_types }}"
+            volid="AlmaLinux-${releasever}-${arch}"
+            kickstart="almalinux-${{ inputs.version_major }}-live-${image_type,,}.ks"
+            need_pkgs="${need_pkgs} libblockdev-nvme"
+            vm_box='lkhn/almalinux-kitten'
+            ;;
+          10-kitten-x86_64_v2)
+            version_minor=
+            releasever=10
+            arch=x86_64_v2
+            code_name_var=" Kitten"
+            results_name="AlmaLinux-Kitten-10-${date_stamp}.${{ inputs.iteration }}-${arch}-Live-${{ matrix.image_types }}"
+            volid="AlmaLinux-${releasever}-${arch}"
+            kickstart="almalinux-${{ inputs.version_major }}-${arch}-live-${image_type,,}.ks"
+            need_pkgs="${need_pkgs} libblockdev-nvme"
+            vm_box='lkhn/almalinux-kitten-x86-64-v2'
+            ;;
+          *)
             echo "Almalinux ${{ inputs.version_major }} is not supported!" && false
+            ;;
         esac
+
+        # Minor version
         echo "version_minor=${version_minor}" >> $GITHUB_ENV
 
-        # [Debug]
-        echo "version_minor=${version_minor}"
+        # AlmaLinux name
+        echo "code_name_var=${code_name_var}" >> $GITHUB_ENV
 
-    - name: Prepare other stuff
-      run: |
+        # Release version full
+        echo "releasever=${releasever}" >> $GITHUB_ENV
+
         # Name of repository to enable (PowerTools/CRB)
-        dnf_crb_repo="PowerTools"
-        if [ "${{ inputs.version_major }}" = "9" ]; then
-          dnf_crb_repo="CRB"
-        fi
         echo "dnf_crb_repo=${dnf_crb_repo}" >> $GITHUB_ENV
 
         # List of the packages to prepare build env
-        need_pkgs="lorax anaconda zstd"
-        if [ "${{ inputs.version_major }}" = "9" ]; then
-          need_pkgs="${need_pkgs} libblockdev-nvme"
-        fi
         echo "need_pkgs=${need_pkgs}" >> $GITHUB_ENV
 
-        # Verify that CPU supports hardware virtualization
-        echo -n "Number of vmx|svm CPUs: " && grep -E -c '(vmx|svm)' /proc/cpuinfo
+        # livemedia-creator additional options
+        echo "livemedia_creator_opts=${livemedia_creator_opts}" >> $GITHUB_ENV
 
-        # Set ENV variable of for vagrant's config.vm.box
-        cp -av ci/vagrant/Vagrantfile ./
-        echo vm_box='almalinux/${{ inputs.version_major }}' > .env
+        # Architecture
+        echo "arch=${arch}" >> $GITHUB_ENV
 
         # Kickstart file name
-        image_type=${{ matrix.image_types }}
-        image_type="${image_type,,}"
-        kickstart="almalinux-${{ inputs.version_major }}-live-${image_type}.ks"
         echo "kickstart=${kickstart}" >> $GITHUB_ENV
 
         # Livemedia creator results directory
@@ -129,22 +193,30 @@ jobs:
         echo "livemedia_resultdir=${livemedia_resultdir}" >> $GITHUB_ENV
 
         # Volume ID
-        volid="AlmaLinux-${{ inputs.version_major }}_${{ env.version_minor }}-x86_64-Live-${{ matrix.image_types }}"
-        echo ${{ matrix.image_types }} | grep -i mini >/dev/null && volid="AlmaLinux-${{ inputs.version_major }}_${{ env.version_minor }}-x86_64-Live-Mini"
+        if [[ ${{ matrix.image_types }} = *'Mini'* ]]; then
+          volid="${volid}-Mini"
+        else
+          volid="${volid}-${{ matrix.image_types }}"
+        fi
         echo "volid=${volid}" >> $GITHUB_ENV
 
         # Results file base name
-        results_name="AlmaLinux-${{ inputs.version_major }}.${{ env.version_minor }}-x86_64-Live-${{ matrix.image_types }}"
         echo "results_name=${results_name}" >> $GITHUB_ENV
 
-        # date+time stamp
-        date_stamp=$(date -u '+%Y%m%d%H%M%S')
-        echo "date_stamp=${date_stamp}" >> $GITHUB_ENV
+        # date+time stamp, YYYYMMDDhhmmss
+        time_stamp=$(date -u '+%Y%m%d%H%M%S')
+        echo "time_stamp=${time_stamp}" >> $GITHUB_ENV
 
         # Results path on host
         results_path="${{ github.workspace }}/results"
         mkdir -p ${results_path}
         echo "results_path=${results_path}" >> $GITHUB_ENV
+
+        # Set ENV variable of for vagrant's config.vm.box
+        cp -av ci/vagrant/Vagrantfile ./
+        echo vm_box=${vm_box} > .env
+
+        echo -e "[Debug]\nKickstart file: ${kickstart}\nVolume ID: ${volid}\nISO name: ${results_name}.iso\n"
 
     - name: Create media creator script
       run: |
@@ -153,15 +225,14 @@ jobs:
         --ks=/vagrant/kickstarts/${{ env.kickstart }} \
         --no-virt \
         --resultdir ${{ env.livemedia_resultdir }}/iso_${{ matrix.image_types}} \
-        --project "AlmaLinux Live" \
+        --project "Live AlmaLinux${{ env.code_name_var }}" \
         --make-iso \
         --iso-only \
         --iso-name "${{ env.results_name }}.iso" \
-        --releasever 9.${{ env.version_minor }} \
+        --releasever "${{ env.releasever }}" \
         --volid "${{ env.volid }}" \
         --nomacboot \
-        --logfile ${{ env.livemedia_resultdir }}/logs/livemedia.log \
-        --anaconda-arg="--product AlmaLinux"
+        --logfile ${{ env.livemedia_resultdir }}/logs/livemedia.log ${{ env.livemedia_creator_opts }}
         EOF
 
     - name: Install KVM Packages and Start libvirt
@@ -208,7 +279,7 @@ jobs:
         sudo virsh pool-list
 
     - name: Run vagrant up
-      run: sudo vagrant up almalinux
+      run: sudo vagrant up --no-tty almalinux
 
     - name: Prepare build infrastructure
       run: |
@@ -247,7 +318,7 @@ jobs:
       id: logs-artifact
       if: success() || failure()
       with:
-        name: AlmaLinux-${{ inputs.version_major }}.${{ env.version_minor }}-x86_64-Live-${{ matrix.image_types }}-logs.tar
+        name: AlmaLinux-${{ inputs.version_major }}${{ env.version_minor }}-${{ env.arch }}-Live-${{ matrix.image_types }}-logs.tar
         path: ${{ env.results_path }}/*.tar
 
     - uses: actions/upload-artifact@v4
@@ -280,8 +351,8 @@ jobs:
       run: |
         cd ${{ env.results_path }}
         for object in ${{ env.results_name }}.iso ${{ env.results_name }}-logs.tar.zst ${{ env.results_name }}.iso.CHECKSUM; do
-          aws s3 cp ${object} s3://${{ vars.AWS_S3_BUCKET }}/${{ env.date_stamp }}/
-          aws s3api put-object-tagging --bucket ${{ vars.AWS_S3_BUCKET }} --key ${{ env.date_stamp }}/${object} --tagging 'TagSet={Key=public,Value=yes}'
+          aws s3 cp ${object} s3://${{ vars.AWS_S3_BUCKET }}/${{ env.time_stamp }}/
+          aws s3api put-object-tagging --bucket ${{ vars.AWS_S3_BUCKET }} --key ${{ env.time_stamp }}/${object} --tagging 'TagSet={Key=public,Value=yes}'
         done
 
     - name: Put S3 Bucket download URLs
@@ -292,11 +363,11 @@ jobs:
         script: |
           core.summary
               .addHeading('S3 Bucket download URLs', '4')
-              .addLink('${{ env.results_name }}.iso.CHECKSUM', 'https://${{ vars.AWS_S3_BUCKET }}.s3-accelerate.dualstack.amazonaws.com/${{ env.date_stamp }}/${{ env.results_name }}.iso.CHECKSUM')
+              .addLink('${{ env.results_name }}.iso.CHECKSUM', 'https://${{ vars.AWS_S3_BUCKET }}.s3-accelerate.dualstack.amazonaws.com/${{ env.time_stamp }}/${{ env.results_name }}.iso.CHECKSUM')
               .addBreak()
-              .addLink('${{ env.results_name }}.iso', 'https://${{ vars.AWS_S3_BUCKET }}.s3-accelerate.dualstack.amazonaws.com/${{ env.date_stamp }}/${{ env.results_name }}.iso')
+              .addLink('${{ env.results_name }}.iso', 'https://${{ vars.AWS_S3_BUCKET }}.s3-accelerate.dualstack.amazonaws.com/${{ env.time_stamp }}/${{ env.results_name }}.iso')
               .addBreak()
-              .addLink('${{ env.results_name }}-logs.tar.zst', 'https://${{ vars.AWS_S3_BUCKET }}.s3-accelerate.dualstack.amazonaws.com/${{ env.date_stamp }}/${{ env.results_name }}-logs.tar.zst')
+              .addLink('${{ env.results_name }}-logs.tar.zst', 'https://${{ vars.AWS_S3_BUCKET }}.s3-accelerate.dualstack.amazonaws.com/${{ env.time_stamp }}/${{ env.results_name }}-logs.tar.zst')
               .write()
 
     - name: Send notification to Mattermost (AWS S3 links)
@@ -307,14 +378,15 @@ jobs:
         MATTERMOST_CHANNEL: ${{ vars.MATTERMOST_CHANNEL }}
         MATTERMOST_USERNAME: ${{ github.triggering_actor }}
         TEXT: |
-          **AlmaLinux OS 9.${{ env.version_minor }} Live Media Build** `${{ env.date_stamp }}` generated by the GitHub [Action](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          **CHECKSUM(SHA256):** https://${{ vars.AWS_S3_BUCKET }}.s3-accelerate.dualstack.amazonaws.com/${{ env.date_stamp }}/${{ env.results_name }}.iso.CHECKSUM
+          **AlmaLinux OS${{ env.code_name_var }} ${{ env.releasever }} ${{ env.arch }} Live Media Build** `${{ env.time_stamp }}` generated by the GitHub [Action](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
-          **ISO:**
-          - ${{ matrix.image_types }}: https://${{ vars.AWS_S3_BUCKET }}.s3-accelerate.dualstack.amazonaws.com/${{ env.date_stamp }}/${{ env.results_name }}.iso
+          :almalinux: **${{ matrix.image_types }}**
 
-          **Logs:**
-          - ${{ matrix.image_types }}: https://${{ vars.AWS_S3_BUCKET }}.s3-accelerate.dualstack.amazonaws.com/${{ env.date_stamp }}/${{ env.results_name }}-logs.tar.zst
+          - CHECKSUM(SHA256): [${{ env.results_name }}.iso.CHECKSUM](https://${{ vars.AWS_S3_BUCKET }}.s3-accelerate.dualstack.amazonaws.com/${{ env.time_stamp }}/${{ env.results_name }}.iso.CHECKSUM)
+
+          - ISO: [${{ env.results_name }}.iso](https://${{ vars.AWS_S3_BUCKET }}.s3-accelerate.dualstack.amazonaws.com/${{ env.time_stamp }}/${{ env.results_name }}.iso)
+
+          - Logs: [${{ env.results_name }}-logs.tar.zst](https://${{ vars.AWS_S3_BUCKET }}.s3-accelerate.dualstack.amazonaws.com/${{ env.time_stamp }}/${{ env.results_name }}-logs.tar.zst)
 
     - name: Send notification to Mattermost (Artifacts)
       uses: mattermost/action-mattermost-notify@master
@@ -324,11 +396,12 @@ jobs:
         MATTERMOST_CHANNEL: ${{ vars.MATTERMOST_CHANNEL }}
         MATTERMOST_USERNAME: ${{ github.triggering_actor }}
         TEXT: |
-          **AlmaLinux OS 9.${{ env.version_minor }} Live Media Build** `${{ env.date_stamp }}` generated by the GitHub [Action](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          **CHECKSUM(SHA256) [zipped]:** ${{ steps.checksum-artifact.outputs.artifact-url }}
+          **AlmaLinux OS${{ env.code_name_var }} ${{ env.releasever }} ${{ env.arch }} Live Media Build** `${{ env.time_stamp }}` generated by the GitHub [Action](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
-          **ISO [zipped]:**
-          - ${{ matrix.image_types }}: ${{ steps.iso-artifact.outputs.artifact-url }}
+          :almalinux: **${{ matrix.image_types }}**
 
-          **Logs [zipped]:**
-          - ${{ matrix.image_types }}: ${{ steps.logs-artifact.outputs.artifact-url }}
+          - CHECKSUM(SHA256) [zipped]: [${{ env.results_name }}.iso.CHECKSUM](${{ steps.checksum-artifact.outputs.artifact-url }})
+
+          - ISO [zipped]: [${{ env.results_name }}.iso](${{ steps.iso-artifact.outputs.artifact-url }})
+
+          - Logs [zipped]: [${{ env.results_name }}-logs.tar.zst](${{ steps.logs-artifact.outputs.artifact-url }})

--- a/kickstarts/almalinux-10-kitten-live-gnome-mini.ks
+++ b/kickstarts/almalinux-10-kitten-live-gnome-mini.ks
@@ -1,0 +1,161 @@
+# AlmaLinux Live Media (Beta - experimental), with optional install option.
+# Build: sudo livecd-creator --cache=~/livecd-creator/package-cache -c almalinux-8-live-gnome.ks -f AlmaLinux-8-Live-gnome
+# X Window System configuration information
+xconfig  --startxonboot
+# Keyboard layouts
+keyboard 'us'
+
+# System timezone
+timezone US/Eastern
+# System language
+lang en_US.UTF-8
+# Firewall configuration
+firewall --enabled --service=mdns
+
+# Repos
+url --url=https://kitten.repo.almalinux.org/10-kitten/BaseOS/$basearch/os/
+repo --name="appstream" --baseurl=https://kitten.repo.almalinux.org/10-kitten/AppStream/$basearch/os/
+repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extras-common/$basearch/os/
+repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/$basearch/os/
+repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
+
+
+# Network information
+network --activate --bootproto=dhcp --device=link --onboot=on
+
+# SELinux configuration
+selinux --enforcing
+
+# System services
+services --disabled="sshd" --enabled="NetworkManager,ModemManager"
+
+# livemedia-creator modifications.
+shutdown
+# System bootloader configuration
+bootloader --location=none
+# Clear blank disks or all existing partitions
+clearpart --all --initlabel
+rootpw rootme
+# Disk partitioning information
+part / --size=10238
+
+%post
+# Enable livesys services
+systemctl enable livesys.service
+systemctl enable livesys-late.service
+
+# enable tmpfs for /tmp
+systemctl enable tmp.mount
+
+# make it so that we don't do writing to the overlay for things which
+# are just tmpdirs/caches
+# note https://bugzilla.redhat.com/show_bug.cgi?id=1135475
+cat >> /etc/fstab << EOF
+vartmp   /var/tmp    tmpfs   defaults   0  0
+EOF
+
+# work around for poor key import UI in PackageKit
+rm -f /var/lib/rpm/__db*
+# import AlmaLinux PGP key
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
+echo "Packages within this LiveCD"
+rpm -qa
+# Note that running rpm recreates the rpm db files which aren't needed or wanted
+rm -f /var/lib/rpm/__db*
+
+# go ahead and pre-make the man -k cache (#455968)
+/usr/bin/mandb
+
+# make sure there aren't core files lying around
+rm -f /core*
+
+# convince readahead not to collect
+# FIXME: for systemd
+
+echo 'File created by kickstart. See systemd-update-done.service(8).' \
+    | tee /etc/.updated >/var/.updated
+
+# Remove random-seed
+rm /var/lib/systemd/random-seed
+
+# Remove the rescue kernel and image to save space
+# Installation will recreate these on the target
+rm -f /boot/*-rescue*
+
+# Disable network service here, as doing it in the services line
+# fails due to RHBZ #1369794
+systemctl disable network
+
+# Remove machine-id on pre generated images
+rm -f /etc/machine-id
+touch /etc/machine-id
+
+# set livesys session type
+sed -i 's/^livesys_session=.*/livesys_session="gnome"/' /etc/sysconfig/livesys
+
+# Workaround to add openvpn user and group in case they didn't added during
+# openvpn package installation
+getent group openvpn &>/dev/null || groupadd -r openvpn
+getent passwd openvpn &>/dev/null || \
+    /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
+        -d /etc/openvpn openvpn
+
+%end
+
+# Packages
+%packages
+# Explicitly specified mandatory packages
+kernel
+kernel-modules
+kernel-modules-extra
+
+# The point of a live image is to install
+anaconda
+anaconda-install-env-deps
+anaconda-live
+@anaconda-tools
+# Anaconda has a weak dep on this and we don't want it on livecds, see
+# https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD
+-fcoe-utils
+-sdubby
+
+# Need aajohan-comfortaa-fonts for the SVG rnotes images
+#aajohan-comfortaa-fonts
+
+# Without this, initramfs generation during live image creation fails: #1242586
+dracut-live
+
+# anaconda needs the locales available to run for different locales
+glibc-all-langpacks
+
+# provide the livesys scripts
+livesys-scripts
+
+# Mandatory to build media with livemedia-creator
+memtest86+
+
+# firefox
+#@internet-browser
+firefox
+
+# Workstation environment group
+@^workstation-product-environment
+
+# Workstation specific
+-@workstation-product
+
+# GNOME specific
+@gnome-desktop
+
+# OpenVPN
+#openvpn
+#NetworkManager-openvpn
+#NetworkManager-openvpn-gnome
+
+# Exclude unwanted packages from @anaconda-tools group
+-gfs2-utils
+-reiserfs-utils
+
+# minimization
+-hplip
+%end

--- a/kickstarts/almalinux-10-kitten-live-gnome.ks
+++ b/kickstarts/almalinux-10-kitten-live-gnome.ks
@@ -1,0 +1,172 @@
+# AlmaLinux Live Media (Beta - experimental), with optional install option.
+# Build: sudo livecd-creator --cache=~/livecd-creator/package-cache -c almalinux-8-live-gnome.ks -f AlmaLinux-8-Live-gnome
+# X Window System configuration information
+xconfig  --startxonboot
+# Keyboard layouts
+keyboard 'us'
+
+# System timezone
+timezone US/Eastern
+# System language
+lang en_US.UTF-8
+# Firewall configuration
+firewall --enabled --service=mdns
+
+# Repos
+url --url=https://kitten.repo.almalinux.org/10-kitten/BaseOS/$basearch/os/
+repo --name="appstream" --baseurl=https://kitten.repo.almalinux.org/10-kitten/AppStream/$basearch/os/
+repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extras-common/$basearch/os/
+repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/$basearch/os/
+repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
+
+# Network information
+network --activate --bootproto=dhcp --device=link --onboot=on
+
+# SELinux configuration
+selinux --enforcing
+
+# System services
+services --disabled="sshd" --enabled="NetworkManager,ModemManager"
+
+# livemedia-creator modifications.
+shutdown
+# System bootloader configuration
+bootloader --location=none
+# Clear blank disks or all existing partitions
+clearpart --all --initlabel
+rootpw rootme
+# Disk partitioning information
+part / --size=10238
+
+%post
+# Enable livesys services
+systemctl enable livesys.service
+systemctl enable livesys-late.service
+
+# enable tmpfs for /tmp
+systemctl enable tmp.mount
+
+# make it so that we don't do writing to the overlay for things which
+# are just tmpdirs/caches
+# note https://bugzilla.redhat.com/show_bug.cgi?id=1135475
+cat >> /etc/fstab << EOF
+vartmp   /var/tmp    tmpfs   defaults   0  0
+EOF
+
+# work around for poor key import UI in PackageKit
+rm -f /var/lib/rpm/__db*
+# import AlmaLinux PGP key
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
+echo "Packages within this LiveCD"
+rpm -qa
+# Note that running rpm recreates the rpm db files which aren't needed or wanted
+rm -f /var/lib/rpm/__db*
+
+# go ahead and pre-make the man -k cache (#455968)
+/usr/bin/mandb
+
+# make sure there aren't core files lying around
+rm -f /core*
+
+# convince readahead not to collect
+# FIXME: for systemd
+
+echo 'File created by kickstart. See systemd-update-done.service(8).' \
+    | tee /etc/.updated >/var/.updated
+
+# Remove random-seed
+rm /var/lib/systemd/random-seed
+
+# Remove the rescue kernel and image to save space
+# Installation will recreate these on the target
+rm -f /boot/*-rescue*
+
+# Disable network service here, as doing it in the services line
+# fails due to RHBZ #1369794
+systemctl disable network
+
+# Remove machine-id on pre generated images
+rm -f /etc/machine-id
+touch /etc/machine-id
+
+# set livesys session type
+sed -i 's/^livesys_session=.*/livesys_session="gnome"/' /etc/sysconfig/livesys
+
+# Workaround to add openvpn user and group in case they didn't added during
+# openvpn package installation
+getent group openvpn &>/dev/null || groupadd -r openvpn
+getent passwd openvpn &>/dev/null || \
+    /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
+        -d /etc/openvpn openvpn
+
+%end
+
+# Packages
+%packages
+# Explicitly specified mandatory packages
+kernel
+kernel-modules
+kernel-modules-extra
+
+# The point of a live image is to install
+anaconda
+anaconda-install-env-deps
+anaconda-live
+@anaconda-tools
+# Anaconda has a weak dep on this and we don't want it on livecds, see
+# https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD
+-fcoe-utils
+-sdubby
+
+# Need aajohan-comfortaa-fonts for the SVG rnotes images
+#aajohan-comfortaa-fonts
+
+# Without this, initramfs generation during live image creation fails: #1242586
+dracut-live
+
+# anaconda needs the locales available to run for different locales
+glibc-all-langpacks
+
+# provide the livesys scripts
+livesys-scripts
+
+# Mandatory to build media with livemedia-creator
+memtest86+
+
+# libreoffice group
+#@office-suite
+
+# Workstation environment group
+@^workstation-product-environment
+
+# GNOME specific
+@gnome-apps
+
+# Exclude unwanted packages from @anaconda-tools group
+-gfs2-utils
+-reiserfs-utils
+
+# Workstation specific
+bash-color-prompt
+exfatprogs
+fpaste
+#iptstate
+nss-mdns
+#ntfs-3g
+#ntfsprogs
+policycoreutils-python-utils
+psmisc
+python3-dnf-plugin-system-upgrade
+toolbox
+#unoconv
+uresourced
+whois
+
+# OpenVPN
+#openvpn
+#NetworkManager-openvpn
+#NetworkManager-openvpn-gnome
+
+# minimization
+-hplip
+%end

--- a/kickstarts/almalinux-10-kitten-live-kde.ks
+++ b/kickstarts/almalinux-10-kitten-live-kde.ks
@@ -1,0 +1,259 @@
+#version=DEVEL
+# X Window System configuration information
+xconfig  --startxonboot
+# Keyboard layouts
+keyboard 'us'
+# Root password
+rootpw --plaintext rootme
+# System language
+lang en_US.UTF-8
+# Shutdown after installation
+shutdown
+# System timezone
+timezone US/Eastern
+# Network information
+network  --bootproto=dhcp --device=link --activate
+
+# Repos
+url --url=https://kitten.repo.almalinux.org/10-kitten/BaseOS/$basearch/os/
+repo --name="appstream" --baseurl=https://kitten.repo.almalinux.org/10-kitten/AppStream/$basearch/os/
+repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extras-common/$basearch/os/
+repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/$basearch/os/
+repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
+
+# Firewall configuration
+firewall --enabled --service=mdns
+# SELinux configuration
+selinux --enforcing
+
+# System services
+services --disabled="sshd" --enabled="NetworkManager,ModemManager"
+# System bootloader configuration
+bootloader --location=none
+# Clear the Master Boot Record
+zerombr
+# Partition clearing information
+clearpart --all --initlabel
+# Disk partitioning information
+part / --size=10238
+
+%post
+
+# Enable livesys services
+systemctl enable livesys.service
+systemctl enable livesys-late.service
+
+# Enable sddm since EPEL packages it disabled by default
+systemctl enable sddm.service
+
+# enable tmpfs for /tmp
+systemctl enable tmp.mount
+
+# make it so that we don't do writing to the overlay for things which
+# are just tmpdirs/caches
+# note https://bugzilla.redhat.com/show_bug.cgi?id=1135475
+cat >> /etc/fstab << EOF
+vartmp   /var/tmp    tmpfs   defaults   0  0
+EOF
+
+# work around for poor key import UI in PackageKit
+rm -f /var/lib/rpm/__db*
+# import AlmaLinux PGP key
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
+echo "Packages within this LiveCD"
+rpm -qa
+# Note that running rpm recreates the rpm db files which aren't needed or wanted
+rm -f /var/lib/rpm/__db*
+
+# go ahead and pre-make the man -k cache (#455968)
+/usr/bin/mandb
+
+# make sure there aren't core files lying around
+rm -f /core*
+
+# remove random seed, the newly installed instance should make it's own
+rm -f /var/lib/systemd/random-seed
+
+# convince readahead not to collect
+# FIXME: for systemd
+
+echo 'File created by kickstart. See systemd-update-done.service(8).' \
+    | tee /etc/.updated >/var/.updated
+
+# Drop the rescue kernel and initramfs, we don't need them on the live media itself.
+# See bug 1317709
+rm -f /boot/*-rescue*
+
+# TODO: almalinux-backgrounds-extras package looks good, remove inline method
+# on next build
+generateKDEWallpapers() {
+  # Declare an array for background types
+  declare -a bgtypes=("dark" "light" "abstract-dark" "abstract-light" "mountains-dark" "mountains-white" "waves-dark" "waves-light" "waves-sunset")
+  # Declare an array for background sizes
+  declare -a sizes=("1800x1440.jpg" "2048x1536.jpg" "2560x1080.jpg" "2560x1440.jpg" "2560x1600.jpg" "3440x1440.jpg")
+  ## Loop through the above array(s) types and sizes to create links and metadata
+  for bg in "${bgtypes[@]}"
+  do
+    echo "Processing 'Alma-"$bg"' background"
+    # Remove any old folders and create new structure
+    rm -rf /usr/share/wallpapers/Alma-$bg*
+    mkdir -p /usr/share/wallpapers/Alma-$bg/contents/images/
+    # creae sym link for all sizes
+    for size in "${sizes[@]}"
+    do
+    ln -s /usr/share/backgrounds/Alma-$bg-$size /usr/share/wallpapers/Alma-$bg/contents/images/$size
+    done
+    # Create metadata file to make Desktop Wallpaper application happy
+    # Move this to pre-created files in repo to give support to other languages
+    # This is quick hack for time being.
+    cat > /usr/share/wallpapers/Alma-$bg/metadata.desktop <<FOE
+[Desktop Entry]
+Name=AlmaLinux $bg
+
+X-KDE-PluginInfo-Author=Bala Raman
+X-KDE-PluginInfo-Email=srbala@gmail.com
+X-KDE-PluginInfo-Name=Alma-$bg
+X-KDE-PluginInfo-Version=0.1.0
+X-KDE-PluginInfo-Website=https://almalinux.org
+X-KDE-PluginInfo-Category=
+X-KDE-PluginInfo-Depends=
+X-KDE-PluginInfo-License=CC-BY-SA
+X-KDE-PluginInfo-EnabledByDefault=true
+X-Plasma-API=5.0
+
+FOE
+  done
+}
+# call function to create wallpapers
+# generateKDEWallpapers
+# Very ODD fix to get Alma background, find alternative
+rm -rf /usr/share/wallpapers/Fedora
+ln -s Alma-mountains-white /usr/share/wallpapers/Fedora
+# background end
+
+# Update default theme - this has to stay KS
+# Hack KDE Fedora package starts. TODO: need almalinux-kde-fix package
+sed -i 's/defaultWallpaperTheme=Fedora/defaultWallpaperTheme=Alma-mountains-white/' /usr/share/plasma/desktoptheme/default/metadata.desktop
+sed -i 's/defaultFileSuffix=.png/defaultFileSuffix=.jpg/' /usr/share/plasma/desktoptheme/default/metadata.desktop
+sed -i 's/defaultWidth=1920/defaultWidth=2048/' /usr/share/plasma/desktoptheme/default/metadata.desktop
+sed -i 's/defaultHeight=1080/defaultHeight=1536/' /usr/share/plasma/desktoptheme/default/metadata.desktop
+# Update KInfocenter
+sed -i 's/pixmaps\/system-logo-white.png/icons\/hicolor\/256x256\/apps\/fedora-logo-icon.png/' /etc/xdg/kcm-about-distrorc
+sed -i 's/http:\/\/fedoraproject.org/https:\/\/almalinux.org/' /etc/xdg/kcm-about-distrorc
+# Hack KDE Fedora package ends
+
+# Disable network service here, as doing it in the services line
+# fails due to RHBZ #1369794
+systemctl disable network
+
+# Remove machine-id on pre generated images
+rm -f /etc/machine-id
+touch /etc/machine-id
+
+# set livesys session type
+sed -i 's/^livesys_session=.*/livesys_session="kde"/' /etc/sysconfig/livesys
+
+# set default GTK+ theme for root (see #683855, #689070, #808062)
+cat > /root/.gtkrc-2.0 << EOF
+include "/usr/share/themes/Adwaita/gtk-2.0/gtkrc"
+include "/etc/gtk-2.0/gtkrc"
+gtk-theme-name="Adwaita"
+EOF
+mkdir -p /root/.config/gtk-3.0
+cat > /root/.config/gtk-3.0/settings.ini << EOF
+[Settings]
+gtk-theme-name = Adwaita
+EOF
+
+# enable CRB repo
+dnf config-manager --enable crb
+
+# Workaround to add openvpn user and group in case they didn't added during
+# openvpn package installation
+getent group openvpn &>/dev/null || groupadd -r openvpn
+getent passwd openvpn &>/dev/null || \
+    /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
+        -d /etc/openvpn openvpn
+
+%end
+
+%post --nochroot
+# cp $INSTALL_ROOT/usr/share/licenses/*-release/* $LIVE_ROOT/
+
+# only works on x86, x86_64
+if [ "$(uname -i)" = "i386" -o "$(uname -i)" = "x86_64" ]; then
+  if [ ! -d $LIVE_ROOT/LiveOS ]; then mkdir -p $LIVE_ROOT/LiveOS ; fi
+  cp /usr/bin/livecd-iso-to-disk $LIVE_ROOT/LiveOS
+fi
+
+%end
+
+%packages
+# Explicitly specified mandatory packages
+kernel
+kernel-modules
+kernel-modules-extra
+
+# The point of a live image is to install
+anaconda
+anaconda-install-env-deps
+anaconda-live
+@anaconda-tools
+# Anaconda has a weak dep on this and we don't want it on livecds, see
+# https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD
+-fcoe-utils
+-sdubby
+
+# Need aajohan-comfortaa-fonts for the SVG rnotes images
+#aajohan-comfortaa-fonts
+
+# Without this, initramfs generation during live image creation fails: #1242586
+dracut-live
+
+# anaconda needs the locales available to run for different locales
+glibc-all-langpacks
+
+# provide the livesys scripts
+livesys-scripts
+
+# Mandatory to build media with livemedia-creator
+memtest86+
+
+# libreoffice group
+@office-suite
+# firefox
+@internet-browser
+
+# KDE specific
+@dial-up
+@standard
+
+# install env-group to resolve RhBug:1891500
+@^kde-desktop-environment
+-kde-connect
+-kdeconnectd
+-kde-connect-libs
+
+@kde-apps
+@kde-media
+
+# drop tracker stuff pulled in by gtk3 (pagureio:fedora-kde/SIG#124)
+-tracker-miners
+-tracker
+
+# Additional packages that are not default in kde-* groups, but useful
+fuse
+
+### space issues
+-ktorrent			# kget has also basic torrent features (~3 megs)
+-digikam			# digikam has duplicate functionality with gwenview (~28 megs)
+-kipi-plugins			# ~8 megs + drags in Marble
+-krusader			# ~4 megs
+-k3b				# ~15 megs
+
+# minimization
+-hplip
+
+# Add alsa-sof-firmware to all images PR #51
+alsa-sof-firmware
+%end

--- a/kickstarts/almalinux-10-kitten-live-mate.ks
+++ b/kickstarts/almalinux-10-kitten-live-mate.ks
@@ -1,0 +1,305 @@
+#version=DEVEL
+# X Window System configuration information
+xconfig  --startxonboot
+# Keyboard layouts
+keyboard 'us'
+# Root password
+rootpw --plaintext rootme
+# System language
+lang en_US.UTF-8
+# Shutdown after installation
+shutdown
+# System timezone
+timezone US/Eastern
+# Network information
+network  --bootproto=dhcp --device=link --activate
+
+# Repos
+url --url=https://kitten.repo.almalinux.org/10-kitten/BaseOS/$basearch/os/
+repo --name="appstream" --baseurl=https://kitten.repo.almalinux.org/10-kitten/AppStream/$basearch/os/
+repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extras-common/$basearch/os/
+repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/$basearch/os/
+repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
+
+# Firewall configuration
+firewall --enabled --service=mdns
+# SELinux configuration
+selinux --enforcing
+
+# System services
+services --disabled="sshd" --enabled="NetworkManager,ModemManager"
+# System bootloader configuration
+bootloader --location=none
+# Partition clearing information
+clearpart --all --initlabel
+# Disk partitioning information
+part / --size=10238
+
+%post
+
+systemctl enable --force lightdm.service
+
+# Enable livesys services
+systemctl enable livesys.service
+systemctl enable livesys-late.service
+
+# enable tmpfs for /tmp
+systemctl enable tmp.mount
+
+# make it so that we don't do writing to the overlay for things which
+# are just tmpdirs/caches
+# note https://bugzilla.redhat.com/show_bug.cgi?id=1135475
+cat >> /etc/fstab << EOF
+vartmp   /var/tmp    tmpfs   defaults   0  0
+EOF
+
+# work around for poor key import UI in PackageKit
+rm -f /var/lib/rpm/__db*
+# import AlmaLinux PGP key
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
+echo "Packages within this LiveCD"
+rpm -qa
+# Note that running rpm recreates the rpm db files which aren't needed or wanted
+rm -f /var/lib/rpm/__db*
+
+# go ahead and pre-make the man -k cache (#455968)
+/usr/bin/mandb
+
+# make sure there aren't core files lying around
+rm -f /core*
+
+# convince readahead not to collect
+# FIXME: for systemd
+
+echo 'File created by kickstart. See systemd-update-done.service(8).' \
+    | tee /etc/.updated >/var/.updated
+
+# Remove random-seed
+rm /var/lib/systemd/random-seed
+
+# Remove the rescue kernel and image to save space
+# Installation will recreate these on the target
+rm -f /boot/*-rescue*
+
+# Disable network service here, as doing it in the services line
+# fails due to RHBZ #1369794
+systemctl disable network
+
+# Remove machine-id on pre generated images
+rm -f /etc/machine-id
+touch /etc/machine-id
+
+# set livesys session type
+sed -i 's/^livesys_session=.*/livesys_session="mate"/' /etc/sysconfig/livesys
+
+if [ -f /etc/lightdm/slick-greeter.conf ]; then
+  mv /etc/lightdm/slick-greeter.conf  /etc/lightdm/slick-greeter.conf_saved
+fi
+cat > /etc/lightdm/slick-greeter.conf << SLK_EOF
+[Greeter]
+logo=
+SLK_EOF
+
+# enable CRB repo
+dnf config-manager --enable crb
+
+# Workaround to add openvpn user and group in case they didn't added during
+# openvpn package installation
+getent group openvpn &>/dev/null || groupadd -r openvpn
+getent passwd openvpn &>/dev/null || \
+    /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
+        -d /etc/openvpn openvpn
+
+%end
+
+%packages
+# Explicitly specified mandatory packages
+kernel
+kernel-modules
+kernel-modules-extra
+
+# The point of a live image is to install
+anaconda
+anaconda-install-env-deps
+anaconda-live
+@anaconda-tools
+# Anaconda has a weak dep on this and we don't want it on livecds, see
+# https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD
+-fcoe-utils
+-sdubby
+
+# Need aajohan-comfortaa-fonts for the SVG rnotes images
+aajohan-comfortaa-fonts
+
+# Without this, initramfs generation during live image creation fails: #1242586
+dracut-live
+
+# anaconda needs the locales available to run for different locales
+glibc-all-langpacks
+
+# provide the livesys scripts
+livesys-scripts
+
+# Mandatory to build media with livemedia-creator
+memtest86+
+
+# libreoffice group
+@office-suite
+# firefox
+@internet-browser
+
+# We don't provide any MATE environment group, so mandatory groups are
+@networkmanager-submodules
+@dial-up
+@fonts
+@guest-desktop-agents
+@hardware-support
+@input-methods
+@multimedia
+@print-client
+@standard
+@base-x
+
+# MATE specific
+ccsm
+simple-ccsm
+emerald-themes
+emerald
+
+# blacklist applications which breaks mate-desktop
+-audacious
+
+# FIXME; apparently the glibc maintainers dislike this, but it got put into the
+# desktop image at some point.  We won't touch this one for now.
+nss-mdns
+
+# Drop things for size
+-@3d-printing
+-@admin-tools
+-brasero
+-gnome-icon-theme
+-gnome-icon-theme-symbolic
+-gnome-logs
+-gnome-software
+-gnome-user-docs
+
+# Help and art can be big, too
+-gnome-user-docs
+-evolution-help
+
+# Legacy cmdline things we don't want
+-telnet
+
+# @mate-desktop
+NetworkManager-l2tp-gnome
+NetworkManager-libreswan-gnome
+NetworkManager-openconnect-gnome
+NetworkManager-ovs
+NetworkManager-ppp
+NetworkManager-pptp-gnome
+atril
+atril-caja
+atril-thumbnailer
+caja
+caja-actions
+caja-image-converter
+caja-open-terminal
+caja-sendto
+caja-wallpaper
+caja-xattr-tags
+dconf-editor
+engrampa
+eom
+filezilla
+firewall-config
+gnome-disk-utility
+gnome-epub-thumbnailer
+gnome-logs
+gnome-themes-extra
+gparted
+gtk2-engines
+gucharmap
+gvfs-fuse
+gvfs-gphoto2
+gvfs-mtp
+gvfs-smb
+hexchat
+initial-setup-gui
+libmatekbd
+libmatemixer
+libmateweather
+libsecret
+lightdm
+lm_sensors
+marco
+mate-applets
+mate-backgrounds
+mate-calc
+mate-control-center
+mate-desktop
+mate-dictionary
+mate-disk-usage-analyzer
+mate-icon-theme
+mate-media
+mate-menus
+mate-menus-preferences-category-menu
+mate-notification-daemon
+mate-panel
+mate-polkit
+mate-power-manager
+mate-screensaver
+mate-screenshot
+mate-search-tool
+mate-session-manager
+mate-settings-daemon
+mate-system-log
+mate-system-monitor
+mate-terminal
+mate-themes
+mate-user-admin
+mate-user-guide
+mozo
+network-manager-applet
+nm-connection-editor
+orca
+p7zip
+p7zip-plugins
+parole
+pluma
+seahorse
+seahorse-caja
+setroubleshoot
+simple-scan
+slick-greeter-mate
+system-config-printer
+system-config-printer-applet
+thunderbird
+transmission-gtk
+usermode-gtk
+wireplumber
+xdg-user-dirs-gtk
+xmodmap
+xrdb
+yelp
+
+# @mate-applications
+caja-beesu
+caja-share
+firewall-applet
+mate-menu
+mate-sensors-applet
+mate-utils
+pidgin
+pluma-plugins
+tigervnc
+
+# minimization
+-hplip
+
+# OpenVPN
+openvpn
+NetworkManager-openvpn
+
+# Add alsa-sof-firmware to all images PR #51
+alsa-sof-firmware
+%end

--- a/kickstarts/almalinux-10-kitten-live-xfce.ks
+++ b/kickstarts/almalinux-10-kitten-live-xfce.ks
@@ -1,0 +1,265 @@
+#version=DEVEL
+# X Window System configuration information
+xconfig  --startxonboot
+# Keyboard layouts
+keyboard 'us'
+# Root password
+rootpw --plaintext rootme
+# System language
+lang en_US.UTF-8
+# Shutdown after installation
+shutdown
+# System timezone
+timezone US/Eastern
+# Network information
+network  --bootproto=dhcp --device=link --activate
+
+# Repos
+url --url=https://kitten.repo.almalinux.org/10-kitten/BaseOS/$basearch/os/
+repo --name="appstream" --baseurl=https://kitten.repo.almalinux.org/10-kitten/AppStream/$basearch/os/
+repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extras-common/$basearch/os/
+repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/$basearch/os/
+repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
+
+# Firewall configuration
+firewall --enabled --service=mdns
+# SELinux configuration
+selinux --enforcing
+
+# System services
+services --disabled="sshd" --enabled="NetworkManager,ModemManager"
+# System bootloader configuration
+bootloader --location=none
+# Partition clearing information
+clearpart --all --initlabel
+# Disk partitioning information
+part / --size=10238
+
+%post
+
+# Enable livesys services
+systemctl enable livesys.service
+systemctl enable livesys-late.service
+
+# enable tmpfs for /tmp
+systemctl enable tmp.mount
+
+# make it so that we don't do writing to the overlay for things which
+# are just tmpdirs/caches
+# note https://bugzilla.redhat.com/show_bug.cgi?id=1135475
+cat >> /etc/fstab << EOF
+vartmp   /var/tmp    tmpfs   defaults   0  0
+EOF
+
+# work around for poor key import UI in PackageKit
+rm -f /var/lib/rpm/__db*
+# import AlmaLinux PGP key
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
+echo "Packages within this LiveCD"
+rpm -qa
+# Note that running rpm recreates the rpm db files which aren't needed or wanted
+rm -f /var/lib/rpm/__db*
+
+# go ahead and pre-make the man -k cache (#455968)
+/usr/bin/mandb
+
+# make sure there aren't core files lying around
+rm -f /core*
+
+# remove random seed, the newly installed instance should make it's own
+rm -f /var/lib/systemd/random-seed
+
+# convince readahead not to collect
+# FIXME: for systemd
+
+echo 'File created by kickstart. See systemd-update-done.service(8).' \
+    | tee /etc/.updated >/var/.updated
+
+# Drop the rescue kernel and initramfs, we don't need them on the live media itself.
+# See bug 1317709
+rm -f /boot/*-rescue*
+
+# Disable network service here, as doing it in the services line
+# fails due to RHBZ #1369794
+systemctl disable network
+
+# Remove machine-id on pre generated images
+rm -f /etc/machine-id
+touch /etc/machine-id
+
+# set livesys session type
+sed -i 's/^livesys_session=.*/livesys_session="xfce"/' /etc/sysconfig/livesys
+
+# xfce configuration
+
+# create /etc/sysconfig/desktop (needed for installation)
+
+cat > /etc/sysconfig/desktop <<EOF
+PREFERRED=/usr/bin/startxfce4
+DISPLAYMANAGER=/usr/sbin/lightdm
+EOF
+
+# add bookmarks for popular folders on Thunar’s Places
+cat > /var/lib/livesys/livesys-session-late-extra <<EOF
+#!/bin/bash
+
+gtk_user_path=/home/liveuser/.config/gtk-3.0
+mkdir -p -m 0755 \$gtk_user_path
+chown liveuser:liveuser \$gtk_user_path
+for favorite in Documents Downloads Music Pictures Videos; do
+  # That's good idea to check whether /home/liveuser/\$favorite exists, 
+  # but it does not at the time livesys-session-late-extra runs
+  grep \$favorite \$gtk_user_path/bookmarks >/dev/null 2>&1 || echo "file:///home/liveuser/\$favorite" >> \$gtk_user_path/bookmarks
+done
+chown liveuser:liveuser \$gtk_user_path/bookmarks
+EOF
+chmod +x /var/lib/livesys/livesys-session-late-extra
+
+# enable CRB repo
+dnf config-manager --enable crb
+
+# Workaround to add openvpn user and group in case they didn't added during
+# openvpn package installation
+getent group openvpn &>/dev/null || groupadd -r openvpn
+getent passwd openvpn &>/dev/null || \
+    /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
+        -d /etc/openvpn openvpn
+
+%end
+
+%post --nochroot
+# cp $INSTALL_ROOT/usr/share/licenses/*-release/* $LIVE_ROOT/
+
+# only works on x86, x86_64
+if [ "$(uname -i)" = "i386" -o "$(uname -i)" = "x86_64" ]; then
+  if [ ! -d $LIVE_ROOT/LiveOS ]; then mkdir -p $LIVE_ROOT/LiveOS ; fi
+  cp /usr/bin/livecd-iso-to-disk $LIVE_ROOT/LiveOS
+fi
+
+%end
+
+%packages
+# Explicitly specified mandatory packages
+kernel
+kernel-modules
+kernel-modules-extra
+
+# The point of a live image is to install
+anaconda
+anaconda-install-env-deps
+anaconda-live
+@anaconda-tools
+# Anaconda has a weak dep on this and we don't want it on livecds, see
+# https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD
+-fcoe-utils
+-sdubby
+
+# Need aajohan-comfortaa-fonts for the SVG rnotes images
+aajohan-comfortaa-fonts
+
+# Without this, initramfs generation during live image creation fails: #1242586
+dracut-live
+
+# anaconda needs the locales available to run for different locales
+glibc-all-langpacks
+
+# provide the livesys scripts
+livesys-scripts
+
+# Mandatory to build media with livemedia-creator
+memtest86+
+
+# libreoffice group
+@office-suite
+# firefox
+@internet-browser
+
+# We don't provide any XFCE environment group, so mandatory groups are
+@networkmanager-submodules
+@dial-up
+@fonts
+@guest-desktop-agents
+@hardware-support
+@input-methods
+@multimedia
+@print-client
+@standard
+@base-x
+
+# XFCE specific
+@xfce-desktop
+-gdm
+lightdm
+lightdm-gobject
+lightdm-gtk
+xfce4-about
+xfce4-notifyd
+xfce4-screenshooter
+xfce4-taskmanager
+xdg-user-dirs-gtk
+
+# @xfce-apps packages
+claws-mail
+claws-mail-plugins-archive
+claws-mail-plugins-att-remover
+claws-mail-plugins-attachwarner
+claws-mail-plugins-fetchinfo
+claws-mail-plugins-mailmbox
+claws-mail-plugins-newmail
+claws-mail-plugins-notification
+claws-mail-plugins-pgp
+claws-mail-plugins-rssyl
+claws-mail-plugins-smime
+claws-mail-plugins-spam-report
+claws-mail-plugins-tnef
+claws-mail-plugins-vcalendar
+geany
+gparted
+mousepad
+pidgin
+ristretto
+seahorse
+transmission
+xarchiver
+xfce4-clipman-plugin
+xfce4-dict-plugin
+
+# @xfce-extra-plugins
+xfce4-cpugraph-plugin
+xfce4-eyes-plugin
+xfce4-fsguard-plugin
+xfce4-genmon-plugin
+xfce4-mailwatch-plugin
+xfce4-mount-plugin
+xfce4-netload-plugin
+xfce4-panel-profiles
+xfce4-sensors-plugin
+xfce4-systemload-plugin
+xfce4-time-out-plugin
+xfce4-verve-plugin
+xfce4-weather-plugin
+xfce4-whiskermenu-plugin
+xfce4-xkb-plugin
+
+# @xfce-media packages
+parole
+
+# save some space
+-autofs
+-acpid
+-gimp-help
+-desktop-backgrounds-basic
+-aspell-*                   # dictionaries are big
+-xfce4-sensors-plugin
+-xfce4-eyes-plugin
+
+# OpenVPN
+openvpn
+NetworkManager-openvpn
+
+# minimization
+-hplip
+
+# Add alsa-sof-firmware to all images PR #51
+alsa-sof-firmware
+%end

--- a/kickstarts/almalinux-10-kitten-x86_64_v2-live-gnome-mini.ks
+++ b/kickstarts/almalinux-10-kitten-x86_64_v2-live-gnome-mini.ks
@@ -1,0 +1,160 @@
+# AlmaLinux Live Media (Beta - experimental), with optional install option.
+# Build: sudo livecd-creator --cache=~/livecd-creator/package-cache -c almalinux-8-live-gnome.ks -f AlmaLinux-8-Live-gnome
+# X Window System configuration information
+xconfig  --startxonboot
+# Keyboard layouts
+keyboard 'us'
+
+# System timezone
+timezone US/Eastern
+# System language
+lang en_US.UTF-8
+# Firewall configuration
+firewall --enabled --service=mdns
+
+# Repos
+url --url=https://kitten.repo.almalinux.org/10-kitten/BaseOS/x86_64_v2/os/
+repo --name="appstream" --baseurl=https://kitten.repo.almalinux.org/10-kitten/AppStream/x86_64_v2/os/
+repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extras-common/x86_64_v2/os/
+repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/x86_64_v2/os/
+
+
+# Network information
+network --activate --bootproto=dhcp --device=link --onboot=on
+
+# SELinux configuration
+selinux --enforcing
+
+# System services
+services --disabled="sshd" --enabled="NetworkManager,ModemManager"
+
+# livemedia-creator modifications.
+shutdown
+# System bootloader configuration
+bootloader --location=none
+# Clear blank disks or all existing partitions
+clearpart --all --initlabel
+rootpw rootme
+# Disk partitioning information
+part / --size=10238
+
+%post
+# Enable livesys services
+systemctl enable livesys.service
+systemctl enable livesys-late.service
+
+# enable tmpfs for /tmp
+systemctl enable tmp.mount
+
+# make it so that we don't do writing to the overlay for things which
+# are just tmpdirs/caches
+# note https://bugzilla.redhat.com/show_bug.cgi?id=1135475
+cat >> /etc/fstab << EOF
+vartmp   /var/tmp    tmpfs   defaults   0  0
+EOF
+
+# work around for poor key import UI in PackageKit
+rm -f /var/lib/rpm/__db*
+# import AlmaLinux PGP key
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
+echo "Packages within this LiveCD"
+rpm -qa
+# Note that running rpm recreates the rpm db files which aren't needed or wanted
+rm -f /var/lib/rpm/__db*
+
+# go ahead and pre-make the man -k cache (#455968)
+/usr/bin/mandb
+
+# make sure there aren't core files lying around
+rm -f /core*
+
+# convince readahead not to collect
+# FIXME: for systemd
+
+echo 'File created by kickstart. See systemd-update-done.service(8).' \
+    | tee /etc/.updated >/var/.updated
+
+# Remove random-seed
+rm /var/lib/systemd/random-seed
+
+# Remove the rescue kernel and image to save space
+# Installation will recreate these on the target
+rm -f /boot/*-rescue*
+
+# Disable network service here, as doing it in the services line
+# fails due to RHBZ #1369794
+systemctl disable network
+
+# Remove machine-id on pre generated images
+rm -f /etc/machine-id
+touch /etc/machine-id
+
+# set livesys session type
+sed -i 's/^livesys_session=.*/livesys_session="gnome"/' /etc/sysconfig/livesys
+
+# Workaround to add openvpn user and group in case they didn't added during
+# openvpn package installation
+getent group openvpn &>/dev/null || groupadd -r openvpn
+getent passwd openvpn &>/dev/null || \
+    /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
+        -d /etc/openvpn openvpn
+
+%end
+
+# Packages
+%packages
+# Explicitly specified mandatory packages
+kernel
+kernel-modules
+kernel-modules-extra
+
+# The point of a live image is to install
+anaconda
+anaconda-install-env-deps
+anaconda-live
+@anaconda-tools
+# Anaconda has a weak dep on this and we don't want it on livecds, see
+# https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD
+-fcoe-utils
+-sdubby
+
+# Need aajohan-comfortaa-fonts for the SVG rnotes images
+#aajohan-comfortaa-fonts
+
+# Without this, initramfs generation during live image creation fails: #1242586
+dracut-live
+
+# anaconda needs the locales available to run for different locales
+glibc-all-langpacks
+
+# provide the livesys scripts
+livesys-scripts
+
+# Mandatory to build media with livemedia-creator
+memtest86+
+
+# firefox
+#@internet-browser
+firefox
+
+# Workstation environment group
+@^workstation-product-environment
+
+# Workstation specific
+-@workstation-product
+
+# GNOME specific
+@gnome-desktop
+
+# OpenVPN
+#openvpn
+#NetworkManager-openvpn
+#NetworkManager-openvpn-gnome
+
+# Exclude unwanted packages from @anaconda-tools group
+-gfs2-utils
+-reiserfs-utils
+
+# minimization
+-hplip
+%end

--- a/kickstarts/almalinux-10-kitten-x86_64_v2-live-gnome.ks
+++ b/kickstarts/almalinux-10-kitten-x86_64_v2-live-gnome.ks
@@ -1,0 +1,171 @@
+# AlmaLinux Live Media (Beta - experimental), with optional install option.
+# Build: sudo livecd-creator --cache=~/livecd-creator/package-cache -c almalinux-8-live-gnome.ks -f AlmaLinux-8-Live-gnome
+# X Window System configuration information
+xconfig  --startxonboot
+# Keyboard layouts
+keyboard 'us'
+
+# System timezone
+timezone US/Eastern
+# System language
+lang en_US.UTF-8
+# Firewall configuration
+firewall --enabled --service=mdns
+
+# Repos
+url --url=https://kitten.repo.almalinux.org/10-kitten/BaseOS/x86_64_v2/os/
+repo --name="appstream" --baseurl=https://kitten.repo.almalinux.org/10-kitten/AppStream/x86_64_v2/os/
+repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extras-common/x86_64_v2/os/
+repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/x86_64_v2/os/
+
+# Network information
+network --activate --bootproto=dhcp --device=link --onboot=on
+
+# SELinux configuration
+selinux --enforcing
+
+# System services
+services --disabled="sshd" --enabled="NetworkManager,ModemManager"
+
+# livemedia-creator modifications.
+shutdown
+# System bootloader configuration
+bootloader --location=none
+# Clear blank disks or all existing partitions
+clearpart --all --initlabel
+rootpw rootme
+# Disk partitioning information
+part / --size=10238
+
+%post
+# Enable livesys services
+systemctl enable livesys.service
+systemctl enable livesys-late.service
+
+# enable tmpfs for /tmp
+systemctl enable tmp.mount
+
+# make it so that we don't do writing to the overlay for things which
+# are just tmpdirs/caches
+# note https://bugzilla.redhat.com/show_bug.cgi?id=1135475
+cat >> /etc/fstab << EOF
+vartmp   /var/tmp    tmpfs   defaults   0  0
+EOF
+
+# work around for poor key import UI in PackageKit
+rm -f /var/lib/rpm/__db*
+# import AlmaLinux PGP key
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
+echo "Packages within this LiveCD"
+rpm -qa
+# Note that running rpm recreates the rpm db files which aren't needed or wanted
+rm -f /var/lib/rpm/__db*
+
+# go ahead and pre-make the man -k cache (#455968)
+/usr/bin/mandb
+
+# make sure there aren't core files lying around
+rm -f /core*
+
+# convince readahead not to collect
+# FIXME: for systemd
+
+echo 'File created by kickstart. See systemd-update-done.service(8).' \
+    | tee /etc/.updated >/var/.updated
+
+# Remove random-seed
+rm /var/lib/systemd/random-seed
+
+# Remove the rescue kernel and image to save space
+# Installation will recreate these on the target
+rm -f /boot/*-rescue*
+
+# Disable network service here, as doing it in the services line
+# fails due to RHBZ #1369794
+systemctl disable network
+
+# Remove machine-id on pre generated images
+rm -f /etc/machine-id
+touch /etc/machine-id
+
+# set livesys session type
+sed -i 's/^livesys_session=.*/livesys_session="gnome"/' /etc/sysconfig/livesys
+
+# Workaround to add openvpn user and group in case they didn't added during
+# openvpn package installation
+getent group openvpn &>/dev/null || groupadd -r openvpn
+getent passwd openvpn &>/dev/null || \
+    /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
+        -d /etc/openvpn openvpn
+
+%end
+
+# Packages
+%packages
+# Explicitly specified mandatory packages
+kernel
+kernel-modules
+kernel-modules-extra
+
+# The point of a live image is to install
+anaconda
+anaconda-install-env-deps
+anaconda-live
+@anaconda-tools
+# Anaconda has a weak dep on this and we don't want it on livecds, see
+# https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD
+-fcoe-utils
+-sdubby
+
+# Need aajohan-comfortaa-fonts for the SVG rnotes images
+#aajohan-comfortaa-fonts
+
+# Without this, initramfs generation during live image creation fails: #1242586
+dracut-live
+
+# anaconda needs the locales available to run for different locales
+glibc-all-langpacks
+
+# provide the livesys scripts
+livesys-scripts
+
+# Mandatory to build media with livemedia-creator
+memtest86+
+
+# libreoffice group
+#@office-suite
+
+# Workstation environment group
+@^workstation-product-environment
+
+# GNOME specific
+@gnome-apps
+
+# Exclude unwanted packages from @anaconda-tools group
+-gfs2-utils
+-reiserfs-utils
+
+# Workstation specific
+bash-color-prompt
+exfatprogs
+#fpaste
+#iptstate
+#nss-mdns
+#ntfs-3g
+#ntfsprogs
+policycoreutils-python-utils
+psmisc
+python3-dnf-plugin-system-upgrade
+toolbox
+#unoconv
+uresourced
+whois
+
+# OpenVPN
+#openvpn
+#NetworkManager-openvpn
+#NetworkManager-openvpn-gnome
+
+# minimization
+-hplip
+%end


### PR DESCRIPTION
- add AlmaLinux Kitten 10 x86_64 kickstarts
- add AlmaLinux Kitten 10 x86_64_v2 GNOME and GNOME-Mini kisckstarts
- build meadias for Kitten 10 x86_64 both v2 and v3
- skip if Kitten 10 x86_64_v2: GNOME, KDE, MATE, XFCE. The reasons are: EPEL for v2 isn't available; if GNOME it exceeds volume ID max length of 32 characters
- temporary skip all medias if Kitten 10 except of GNOME-Mini. EPEL doesn't provide need packages at the moment
- correct Volume ID: 'Live AlmaLinux kitten 10', 'Live AlmaLinux 9.4', 'Live AlmaLinux 8.10'
- correct messege sent to Mattermost