### PR TITLE
Kitten 10 kickstarts: do not install anaconda-live to temporary disable "Install to Hard Drive"

### DIFF
--- a/kickstarts/10-kitten/aarch64/almalinux-live-gnome-mini.ks
+++ b/kickstarts/10-kitten/aarch64/almalinux-live-gnome-mini.ks
@@ -112,7 +112,8 @@ kernel-modules-extra
 # The point of a live image is to install
 anaconda
 anaconda-install-env-deps
-anaconda-live
+# TODO: "Install to Hard Drive" temporary disabled because of https://github.com/rhinstaller/anaconda/discussions/5997
+#anaconda-live
 @anaconda-tools
 # Anaconda has a weak dep on this and we don't want it on livecds, see
 # https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD

--- a/kickstarts/10-kitten/aarch64/almalinux-live-gnome.ks
+++ b/kickstarts/10-kitten/aarch64/almalinux-live-gnome.ks
@@ -111,7 +111,8 @@ kernel-modules-extra
 # The point of a live image is to install
 anaconda
 anaconda-install-env-deps
-anaconda-live
+# TODO: "Install to Hard Drive" temporary disabled because of https://github.com/rhinstaller/anaconda/discussions/5997
+#anaconda-live
 @anaconda-tools
 # Anaconda has a weak dep on this and we don't want it on livecds, see
 # https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD

--- a/kickstarts/10-kitten/aarch64/almalinux-live-kde.ks
+++ b/kickstarts/10-kitten/aarch64/almalinux-live-kde.ks
@@ -197,7 +197,8 @@ kernel-modules-extra
 # The point of a live image is to install
 anaconda
 anaconda-install-env-deps
-anaconda-live
+# TODO: "Install to Hard Drive" temporary disabled because of https://github.com/rhinstaller/anaconda/discussions/5997
+#anaconda-live
 @anaconda-tools
 # Anaconda has a weak dep on this and we don't want it on livecds, see
 # https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD

--- a/kickstarts/10-kitten/aarch64/almalinux-live-mate.ks
+++ b/kickstarts/10-kitten/aarch64/almalinux-live-mate.ks
@@ -121,7 +121,8 @@ kernel-modules-extra
 # The point of a live image is to install
 anaconda
 anaconda-install-env-deps
-anaconda-live
+# TODO: "Install to Hard Drive" temporary disabled because of https://github.com/rhinstaller/anaconda/discussions/5997
+#anaconda-live
 @anaconda-tools
 # Anaconda has a weak dep on this and we don't want it on livecds, see
 # https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD

--- a/kickstarts/10-kitten/aarch64/almalinux-live-xfce.ks
+++ b/kickstarts/10-kitten/aarch64/almalinux-live-xfce.ks
@@ -147,7 +147,8 @@ kernel-modules-extra
 # The point of a live image is to install
 anaconda
 anaconda-install-env-deps
-anaconda-live
+# TODO: "Install to Hard Drive" temporary disabled because of https://github.com/rhinstaller/anaconda/discussions/5997
+#anaconda-live
 @anaconda-tools
 # Anaconda has a weak dep on this and we don't want it on livecds, see
 # https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD

--- a/kickstarts/10-kitten/x86_64/almalinux-live-gnome-mini.ks
+++ b/kickstarts/10-kitten/x86_64/almalinux-live-gnome-mini.ks
@@ -112,7 +112,8 @@ kernel-modules-extra
 # The point of a live image is to install
 anaconda
 anaconda-install-env-deps
-anaconda-live
+# TODO: "Install to Hard Drive" temporary disabled because of https://github.com/rhinstaller/anaconda/discussions/5997
+#anaconda-live
 @anaconda-tools
 # Anaconda has a weak dep on this and we don't want it on livecds, see
 # https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD

--- a/kickstarts/10-kitten/x86_64/almalinux-live-gnome.ks
+++ b/kickstarts/10-kitten/x86_64/almalinux-live-gnome.ks
@@ -111,7 +111,8 @@ kernel-modules-extra
 # The point of a live image is to install
 anaconda
 anaconda-install-env-deps
-anaconda-live
+# TODO: "Install to Hard Drive" temporary disabled because of https://github.com/rhinstaller/anaconda/discussions/5997
+#anaconda-live
 @anaconda-tools
 # Anaconda has a weak dep on this and we don't want it on livecds, see
 # https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD

--- a/kickstarts/10-kitten/x86_64/almalinux-live-kde.ks
+++ b/kickstarts/10-kitten/x86_64/almalinux-live-kde.ks
@@ -197,7 +197,8 @@ kernel-modules-extra
 # The point of a live image is to install
 anaconda
 anaconda-install-env-deps
-anaconda-live
+# TODO: "Install to Hard Drive" temporary disabled because of https://github.com/rhinstaller/anaconda/discussions/5997
+#anaconda-live
 @anaconda-tools
 # Anaconda has a weak dep on this and we don't want it on livecds, see
 # https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD

--- a/kickstarts/10-kitten/x86_64/almalinux-live-mate.ks
+++ b/kickstarts/10-kitten/x86_64/almalinux-live-mate.ks
@@ -121,7 +121,8 @@ kernel-modules-extra
 # The point of a live image is to install
 anaconda
 anaconda-install-env-deps
-anaconda-live
+# TODO: "Install to Hard Drive" temporary disabled because of https://github.com/rhinstaller/anaconda/discussions/5997
+#anaconda-live
 @anaconda-tools
 # Anaconda has a weak dep on this and we don't want it on livecds, see
 # https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD

--- a/kickstarts/10-kitten/x86_64/almalinux-live-xfce.ks
+++ b/kickstarts/10-kitten/x86_64/almalinux-live-xfce.ks
@@ -147,7 +147,8 @@ kernel-modules-extra
 # The point of a live image is to install
 anaconda
 anaconda-install-env-deps
-anaconda-live
+# TODO: "Install to Hard Drive" temporary disabled because of https://github.com/rhinstaller/anaconda/discussions/5997
+#anaconda-live
 @anaconda-tools
 # Anaconda has a weak dep on this and we don't want it on livecds, see
 # https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD

--- a/kickstarts/10-kitten/x86_64_v2/almalinux-live-gnome-mini.ks
+++ b/kickstarts/10-kitten/x86_64_v2/almalinux-live-gnome-mini.ks
@@ -111,7 +111,8 @@ kernel-modules-extra
 # The point of a live image is to install
 anaconda
 anaconda-install-env-deps
-anaconda-live
+# TODO: "Install to Hard Drive" temporary disabled because of https://github.com/rhinstaller/anaconda/discussions/5997
+#anaconda-live
 @anaconda-tools
 # Anaconda has a weak dep on this and we don't want it on livecds, see
 # https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD

--- a/kickstarts/10-kitten/x86_64_v2/almalinux-live-gnome.ks
+++ b/kickstarts/10-kitten/x86_64_v2/almalinux-live-gnome.ks
@@ -110,7 +110,8 @@ kernel-modules-extra
 # The point of a live image is to install
 anaconda
 anaconda-install-env-deps
-anaconda-live
+# TODO: "Install to Hard Drive" temporary disabled because of https://github.com/rhinstaller/anaconda/discussions/5997
+#anaconda-live
 @anaconda-tools
 # Anaconda has a weak dep on this and we don't want it on livecds, see
 # https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD


### PR DESCRIPTION
The reasons are:
https://github.com/rhinstaller/anaconda/discussions/5997
https://gitlab.gnome.org/GNOME/gnome-kiosk/-/issues/40