### PR TITLE
Update kickstarts for 9 GNOME

### DIFF
--- a/kickstarts/9/aarch64/almalinux-live-gnome.ks
+++ b/kickstarts/9/aarch64/almalinux-live-gnome.ks
@@ -130,10 +130,10 @@ glibc-all-langpacks
 # provide the livesys scripts
 livesys-scripts
 
-# libreoffice group
-@office-suite
+# firefox
+@internet-browser
 
-# Workstation environment group
+# Workstation environment group (mandatory)
 @core
 @gnome-desktop
 @standard
@@ -144,6 +144,13 @@ livesys-scripts
 @multimedia
 @networkmanager-submodules
 @print-client
+
+# Workstation environment group (optional)
+@backup-client
+@headless-management
+@internet-applications
+@remote-desktop-clients
+@smart-card
 
 # Exclude unwanted packages from @anaconda-tools group
 -gfs2-utils

--- a/kickstarts/9/x86_64/almalinux-live-gnome.ks
+++ b/kickstarts/9/x86_64/almalinux-live-gnome.ks
@@ -136,6 +136,9 @@ memtest86+
 # libreoffice group
 @office-suite
 
+# firefox
+@internet-browser
+
 # Workstation environment group
 @^workstation-product-environment
 


### PR DESCRIPTION
- x86_64: add @internet-browser
- aarch64: add @internet-browser, @backup-client, @headless-management, @internet-applications, @remote-desktop-clients, @smart-card