### PR TITLE
Update kickstarts for Kitten 10 GNOME

### DIFF
--- a/kickstarts/10-kitten/aarch64/almalinux-live-gnome.ks
+++ b/kickstarts/10-kitten/aarch64/almalinux-live-gnome.ks
@@ -134,7 +134,10 @@ livesys-scripts
 # libreoffice group
 #@office-suite
 
-# Workstation environment group
+# internet-browser group
+firefox
+
+# Workstation environment group (mandatory)
 @core
 @standard
 #@base-x
@@ -144,6 +147,19 @@ livesys-scripts
 @multimedia
 @networkmanager-submodules
 @print-client
+
+# Workstation environment group (optional)
+#@backup-client
+@headless-management
+# internet-applications group
+#evolution
+#evolution-ews
+#evolution-help
+#evolution-mapi
+#hexchat
+thunderbird
+@remote-desktop-clients
+@smart-card
 
 # GNOME specific
 @gnome-desktop

--- a/kickstarts/10-kitten/x86_64/almalinux-live-gnome.ks
+++ b/kickstarts/10-kitten/x86_64/almalinux-live-gnome.ks
@@ -137,6 +137,9 @@ memtest86+
 # libreoffice group
 #@office-suite
 
+# internet-browser group
+firefox
+
 # Workstation environment group
 @^workstation-product-environment
 

--- a/kickstarts/10-kitten/x86_64_v2/almalinux-live-gnome.ks
+++ b/kickstarts/10-kitten/x86_64_v2/almalinux-live-gnome.ks
@@ -136,6 +136,9 @@ memtest86+
 # libreoffice group
 #@office-suite
 
+# internet-browser group
+firefox
+
 # Workstation environment group
 @^workstation-product-environment
 


### PR DESCRIPTION
- x86_64, x86_64_v2: add internet-browser packages: firefox
- aarch64: add internet-browser packages: firefox; @headless-management; internet-applications packages: thunderbird; @remote-desktop-clients; @smart-card.