### PR TITLE
Changes for Kitten and 10 Beta images:

### DIFF
--- a/kickstarts/10-kitten/aarch64/almalinux-live-gnome-mini.ks
+++ b/kickstarts/10-kitten/aarch64/almalinux-live-gnome-mini.ks
@@ -18,7 +18,6 @@ repo --name="appstream" --baseurl=https://kitten.repo.almalinux.org/10-kitten/Ap
 repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extras-common/$basearch/os/
 repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/$basearch/os/
 repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
-repo --name="anaconda-albs" --baseurl=https://build.almalinux.org/pulp/content/builds/AlmaLinux-Kitten-10-aarch64-25058-br/
 
 # Network information
 network --activate --bootproto=dhcp --device=link --onboot=on

--- a/kickstarts/10-kitten/aarch64/almalinux-live-gnome-mini.ks
+++ b/kickstarts/10-kitten/aarch64/almalinux-live-gnome-mini.ks
@@ -18,7 +18,7 @@ repo --name="appstream" --baseurl=https://kitten.repo.almalinux.org/10-kitten/Ap
 repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extras-common/$basearch/os/
 repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/$basearch/os/
 repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
-
+repo --name="anaconda-albs" --baseurl=https://build.almalinux.org/pulp/content/builds/AlmaLinux-Kitten-10-aarch64-25058-br/
 
 # Network information
 network --activate --bootproto=dhcp --device=link --onboot=on
@@ -112,8 +112,7 @@ kernel-modules-extra
 # The point of a live image is to install
 anaconda
 anaconda-install-env-deps
-# TODO: "Install to Hard Drive" temporary disabled because of https://github.com/rhinstaller/anaconda/discussions/5997
-#anaconda-live
+anaconda-live
 @anaconda-tools
 # Anaconda has a weak dep on this and we don't want it on livecds, see
 # https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD

--- a/kickstarts/10-kitten/aarch64/almalinux-live-gnome-mini.ks
+++ b/kickstarts/10-kitten/aarch64/almalinux-live-gnome-mini.ks
@@ -150,9 +150,9 @@ firefox
 @gnome-desktop
 
 # OpenVPN
-#openvpn
-#NetworkManager-openvpn
-#NetworkManager-openvpn-gnome
+openvpn
+NetworkManager-openvpn
+NetworkManager-openvpn-gnome
 
 # Exclude unwanted packages from @anaconda-tools group
 -gfs2-utils

--- a/kickstarts/10-kitten/aarch64/almalinux-live-gnome.ks
+++ b/kickstarts/10-kitten/aarch64/almalinux-live-gnome.ks
@@ -186,9 +186,9 @@ uresourced
 whois
 
 # OpenVPN
-#openvpn
-#NetworkManager-openvpn
-#NetworkManager-openvpn-gnome
+openvpn
+NetworkManager-openvpn
+NetworkManager-openvpn-gnome
 
 # minimization
 -hplip

--- a/kickstarts/10-kitten/aarch64/almalinux-live-gnome.ks
+++ b/kickstarts/10-kitten/aarch64/almalinux-live-gnome.ks
@@ -18,6 +18,7 @@ repo --name="appstream" --baseurl=https://kitten.repo.almalinux.org/10-kitten/Ap
 repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extras-common/$basearch/os/
 repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/$basearch/os/
 repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
+repo --name="anaconda-albs" --baseurl=https://build.almalinux.org/pulp/content/builds/AlmaLinux-Kitten-10-aarch64-25058-br/
 
 # Network information
 network --activate --bootproto=dhcp --device=link --onboot=on
@@ -111,8 +112,7 @@ kernel-modules-extra
 # The point of a live image is to install
 anaconda
 anaconda-install-env-deps
-# TODO: "Install to Hard Drive" temporary disabled because of https://github.com/rhinstaller/anaconda/discussions/5997
-#anaconda-live
+anaconda-live
 @anaconda-tools
 # Anaconda has a weak dep on this and we don't want it on livecds, see
 # https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD

--- a/kickstarts/10-kitten/aarch64/almalinux-live-gnome.ks
+++ b/kickstarts/10-kitten/aarch64/almalinux-live-gnome.ks
@@ -18,7 +18,6 @@ repo --name="appstream" --baseurl=https://kitten.repo.almalinux.org/10-kitten/Ap
 repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extras-common/$basearch/os/
 repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/$basearch/os/
 repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
-repo --name="anaconda-albs" --baseurl=https://build.almalinux.org/pulp/content/builds/AlmaLinux-Kitten-10-aarch64-25058-br/
 
 # Network information
 network --activate --bootproto=dhcp --device=link --onboot=on

--- a/kickstarts/10-kitten/aarch64/almalinux-live-kde.ks
+++ b/kickstarts/10-kitten/aarch64/almalinux-live-kde.ks
@@ -21,7 +21,6 @@ repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extra
 repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/$basearch/os/
 repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
 repo --name="anaconda-albs" --baseurl=https://build.almalinux.org/pulp/content/builds/AlmaLinux-Kitten-10-aarch64-25058-br/
-repo --name="almalinux-backgrounds-extras" --baseurl=https://build.almalinux.org/pulp/content/builds/AlmaLinux-Kitten-10-x86_64-25225-br/
 
 # Firewall configuration
 firewall --enabled --service=mdns
@@ -96,6 +95,15 @@ cat <<'EOF'>/home/liveuser/.config/kscreenlockerrc
 Image=/usr/share/wallpapers/Alma-default/
 PreviewImage=/usr/share/wallpapers/Alma-default/
 EOF
+# Replace live installer icon for the application and welcome center
+cd /usr/share/icons
+anaconda_installer_icon=org.fedoraproject.AnacondaInstaller.svg
+sed -i "s/Icon=.*$/Icon=\/usr\/share\/icons\/hicolor\/scalable\/apps\/${anaconda_installer_icon}/g" \
+  /usr/share/applications/liveinst.desktop
+almalinux_installer_icon=../../../hicolor/scalable/apps/${anaconda_installer_icon}
+ln -sf ${almalinux_installer_icon} breeze/apps/48/${anaconda_installer_icon}
+ln -sf ${almalinux_installer_icon} breeze-dark/apps/48/${anaconda_installer_icon}
+cd - >/dev/null
 
 # Disable network service here, as doing it in the services line
 # fails due to RHBZ #1369794

--- a/kickstarts/10-kitten/aarch64/almalinux-live-kde.ks
+++ b/kickstarts/10-kitten/aarch64/almalinux-live-kde.ks
@@ -20,6 +20,7 @@ repo --name="appstream" --baseurl=https://kitten.repo.almalinux.org/10-kitten/Ap
 repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extras-common/$basearch/os/
 repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/$basearch/os/
 repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
+repo --name="anaconda-albs" --baseurl=https://build.almalinux.org/pulp/content/builds/AlmaLinux-Kitten-10-aarch64-25058-br/
 
 # Firewall configuration
 firewall --enabled --service=mdns
@@ -197,8 +198,7 @@ kernel-modules-extra
 # The point of a live image is to install
 anaconda
 anaconda-install-env-deps
-# TODO: "Install to Hard Drive" temporary disabled because of https://github.com/rhinstaller/anaconda/discussions/5997
-#anaconda-live
+anaconda-live
 @anaconda-tools
 # Anaconda has a weak dep on this and we don't want it on livecds, see
 # https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD

--- a/kickstarts/10-kitten/aarch64/almalinux-live-kde.ks
+++ b/kickstarts/10-kitten/aarch64/almalinux-live-kde.ks
@@ -95,14 +95,8 @@ Image=/usr/share/wallpapers/Alma-default/
 PreviewImage=/usr/share/wallpapers/Alma-default/
 EOF
 # Replace live installer icon for the application and welcome center
-cd /usr/share/icons
-anaconda_installer_icon=org.fedoraproject.AnacondaInstaller.svg
-sed -i "s/Icon=.*$/Icon=\/usr\/share\/icons\/hicolor\/scalable\/apps\/${anaconda_installer_icon}/g" \
+sed -i "s/Icon=.*$/Icon=\/usr\/share\/icons\/hicolor\/scalable\/apps\/org.fedoraproject.AnacondaInstaller.svg/g" \
   /usr/share/applications/liveinst.desktop
-almalinux_installer_icon=../../../hicolor/scalable/apps/${anaconda_installer_icon}
-ln -sf ${almalinux_installer_icon} breeze/apps/48/${anaconda_installer_icon}
-ln -sf ${almalinux_installer_icon} breeze-dark/apps/48/${anaconda_installer_icon}
-cd - >/dev/null
 
 # Disable network service here, as doing it in the services line
 # fails due to RHBZ #1369794

--- a/kickstarts/10-kitten/aarch64/almalinux-live-kde.ks
+++ b/kickstarts/10-kitten/aarch64/almalinux-live-kde.ks
@@ -197,6 +197,10 @@ firefox
 # Additional packages that are not default in kde-* groups, but useful
 fuse
 
+# OpenVPN
+openvpn
+NetworkManager-openvpn
+
 ### space issues
 -ktorrent			# kget has also basic torrent features (~3 megs)
 -digikam			# digikam has duplicate functionality with gwenview (~28 megs)

--- a/kickstarts/10-kitten/aarch64/almalinux-live-kde.ks
+++ b/kickstarts/10-kitten/aarch64/almalinux-live-kde.ks
@@ -20,7 +20,6 @@ repo --name="appstream" --baseurl=https://kitten.repo.almalinux.org/10-kitten/Ap
 repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extras-common/$basearch/os/
 repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/$basearch/os/
 repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
-repo --name="anaconda-albs" --baseurl=https://build.almalinux.org/pulp/content/builds/AlmaLinux-Kitten-10-aarch64-25058-br/
 
 # Firewall configuration
 firewall --enabled --service=mdns

--- a/kickstarts/10-kitten/aarch64/almalinux-live-kde.ks
+++ b/kickstarts/10-kitten/aarch64/almalinux-live-kde.ks
@@ -21,6 +21,7 @@ repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extra
 repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/$basearch/os/
 repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
 repo --name="anaconda-albs" --baseurl=https://build.almalinux.org/pulp/content/builds/AlmaLinux-Kitten-10-aarch64-25058-br/
+repo --name="almalinux-backgrounds-extras" --baseurl=https://build.almalinux.org/pulp/content/builds/AlmaLinux-Kitten-10-x86_64-25225-br/
 
 # Firewall configuration
 firewall --enabled --service=mdns
@@ -85,63 +86,16 @@ echo 'File created by kickstart. See systemd-update-done.service(8).' \
 # See bug 1317709
 rm -f /boot/*-rescue*
 
-# TODO: almalinux-backgrounds-extras package looks good, remove inline method
-# on next build
-generateKDEWallpapers() {
-  # Declare an array for background types
-  declare -a bgtypes=("dark" "light" "abstract-dark" "abstract-light" "mountains-dark" "mountains-white" "waves-dark" "waves-light" "waves-sunset")
-  # Declare an array for background sizes
-  declare -a sizes=("1800x1440.jpg" "2048x1536.jpg" "2560x1080.jpg" "2560x1440.jpg" "2560x1600.jpg" "3440x1440.jpg")
-  ## Loop through the above array(s) types and sizes to create links and metadata
-  for bg in "${bgtypes[@]}"
-  do
-    echo "Processing 'Alma-"$bg"' background"
-    # Remove any old folders and create new structure
-    rm -rf /usr/share/wallpapers/Alma-$bg*
-    mkdir -p /usr/share/wallpapers/Alma-$bg/contents/images/
-    # creae sym link for all sizes
-    for size in "${sizes[@]}"
-    do
-    ln -s /usr/share/backgrounds/Alma-$bg-$size /usr/share/wallpapers/Alma-$bg/contents/images/$size
-    done
-    # Create metadata file to make Desktop Wallpaper application happy
-    # Move this to pre-created files in repo to give support to other languages
-    # This is quick hack for time being.
-    cat > /usr/share/wallpapers/Alma-$bg/metadata.desktop <<FOE
-[Desktop Entry]
-Name=AlmaLinux $bg
-
-X-KDE-PluginInfo-Author=Bala Raman
-X-KDE-PluginInfo-Email=srbala@gmail.com
-X-KDE-PluginInfo-Name=Alma-$bg
-X-KDE-PluginInfo-Version=0.1.0
-X-KDE-PluginInfo-Website=https://almalinux.org
-X-KDE-PluginInfo-Category=
-X-KDE-PluginInfo-Depends=
-X-KDE-PluginInfo-License=CC-BY-SA
-X-KDE-PluginInfo-EnabledByDefault=true
-X-Plasma-API=5.0
-
-FOE
-  done
-}
-# call function to create wallpapers
-# generateKDEWallpapers
-# Very ODD fix to get Alma background, find alternative
-rm -rf /usr/share/wallpapers/Fedora
-ln -s Alma-mountains-white /usr/share/wallpapers/Fedora
-# background end
-
-# Update default theme - this has to stay KS
-# Hack KDE Fedora package starts. TODO: need almalinux-kde-fix package
-sed -i 's/defaultWallpaperTheme=Fedora/defaultWallpaperTheme=Alma-mountains-white/' /usr/share/plasma/desktoptheme/default/metadata.desktop
-sed -i 's/defaultFileSuffix=.png/defaultFileSuffix=.jpg/' /usr/share/plasma/desktoptheme/default/metadata.desktop
-sed -i 's/defaultWidth=1920/defaultWidth=2048/' /usr/share/plasma/desktoptheme/default/metadata.desktop
-sed -i 's/defaultHeight=1080/defaultHeight=1536/' /usr/share/plasma/desktoptheme/default/metadata.desktop
-# Update KInfocenter
-sed -i 's/pixmaps\/system-logo-white.png/icons\/hicolor\/256x256\/apps\/fedora-logo-icon.png/' /etc/xdg/kcm-about-distrorc
-sed -i 's/http:\/\/fedoraproject.org/https:\/\/almalinux.org/' /etc/xdg/kcm-about-distrorc
-# Hack KDE Fedora package ends
+# Theme wallpapers
+rm -f /usr/share/wallpapers/Fedora
+ln -s Alma-default /usr/share/wallpapers/Fedora
+# Locked screen wallpapers
+mkdir -p /home/liveuser/.config && chown -R liveuser:liveuser /home/liveuser/.config
+cat <<'EOF'>/home/liveuser/.config/kscreenlockerrc
+[Greeter][Wallpaper][org.kde.image][General]
+Image=/usr/share/wallpapers/Alma-default/
+PreviewImage=/usr/share/wallpapers/Alma-default/
+EOF
 
 # Disable network service here, as doing it in the services line
 # fails due to RHBZ #1369794

--- a/kickstarts/10-kitten/x86_64/almalinux-live-gnome-mini.ks
+++ b/kickstarts/10-kitten/x86_64/almalinux-live-gnome-mini.ks
@@ -18,7 +18,6 @@ repo --name="appstream" --baseurl=https://kitten.repo.almalinux.org/10-kitten/Ap
 repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extras-common/$basearch/os/
 repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/$basearch/os/
 repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
-repo --name="anaconda-albs" --baseurl=https://build.almalinux.org/pulp/content/builds/AlmaLinux-Kitten-10-x86_64-25058-br/
 
 # Network information
 network --activate --bootproto=dhcp --device=link --onboot=on

--- a/kickstarts/10-kitten/x86_64/almalinux-live-gnome-mini.ks
+++ b/kickstarts/10-kitten/x86_64/almalinux-live-gnome-mini.ks
@@ -18,7 +18,7 @@ repo --name="appstream" --baseurl=https://kitten.repo.almalinux.org/10-kitten/Ap
 repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extras-common/$basearch/os/
 repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/$basearch/os/
 repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
-
+repo --name="anaconda-albs" --baseurl=https://build.almalinux.org/pulp/content/builds/AlmaLinux-Kitten-10-x86_64-25058-br/
 
 # Network information
 network --activate --bootproto=dhcp --device=link --onboot=on
@@ -112,8 +112,7 @@ kernel-modules-extra
 # The point of a live image is to install
 anaconda
 anaconda-install-env-deps
-# TODO: "Install to Hard Drive" temporary disabled because of https://github.com/rhinstaller/anaconda/discussions/5997
-#anaconda-live
+anaconda-live
 @anaconda-tools
 # Anaconda has a weak dep on this and we don't want it on livecds, see
 # https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD

--- a/kickstarts/10-kitten/x86_64/almalinux-live-gnome-mini.ks
+++ b/kickstarts/10-kitten/x86_64/almalinux-live-gnome-mini.ks
@@ -148,9 +148,9 @@ firefox
 @gnome-desktop
 
 # OpenVPN
-#openvpn
-#NetworkManager-openvpn
-#NetworkManager-openvpn-gnome
+openvpn
+NetworkManager-openvpn
+NetworkManager-openvpn-gnome
 
 # Exclude unwanted packages from @anaconda-tools group
 -gfs2-utils

--- a/kickstarts/10-kitten/x86_64/almalinux-live-gnome.ks
+++ b/kickstarts/10-kitten/x86_64/almalinux-live-gnome.ks
@@ -18,7 +18,6 @@ repo --name="appstream" --baseurl=https://kitten.repo.almalinux.org/10-kitten/Ap
 repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extras-common/$basearch/os/
 repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/$basearch/os/
 repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
-repo --name="anaconda-albs" --baseurl=https://build.almalinux.org/pulp/content/builds/AlmaLinux-Kitten-10-x86_64-25058-br/
 
 # Network information
 network --activate --bootproto=dhcp --device=link --onboot=on

--- a/kickstarts/10-kitten/x86_64/almalinux-live-gnome.ks
+++ b/kickstarts/10-kitten/x86_64/almalinux-live-gnome.ks
@@ -168,9 +168,9 @@ uresourced
 whois
 
 # OpenVPN
-#openvpn
-#NetworkManager-openvpn
-#NetworkManager-openvpn-gnome
+openvpn
+NetworkManager-openvpn
+NetworkManager-openvpn-gnome
 
 # minimization
 -hplip

--- a/kickstarts/10-kitten/x86_64/almalinux-live-gnome.ks
+++ b/kickstarts/10-kitten/x86_64/almalinux-live-gnome.ks
@@ -18,6 +18,7 @@ repo --name="appstream" --baseurl=https://kitten.repo.almalinux.org/10-kitten/Ap
 repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extras-common/$basearch/os/
 repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/$basearch/os/
 repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
+repo --name="anaconda-albs" --baseurl=https://build.almalinux.org/pulp/content/builds/AlmaLinux-Kitten-10-x86_64-25058-br/
 
 # Network information
 network --activate --bootproto=dhcp --device=link --onboot=on
@@ -111,8 +112,7 @@ kernel-modules-extra
 # The point of a live image is to install
 anaconda
 anaconda-install-env-deps
-# TODO: "Install to Hard Drive" temporary disabled because of https://github.com/rhinstaller/anaconda/discussions/5997
-#anaconda-live
+anaconda-live
 @anaconda-tools
 # Anaconda has a weak dep on this and we don't want it on livecds, see
 # https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD

--- a/kickstarts/10-kitten/x86_64/almalinux-live-kde.ks
+++ b/kickstarts/10-kitten/x86_64/almalinux-live-kde.ks
@@ -200,6 +200,10 @@ firefox
 # Additional packages that are not default in kde-* groups, but useful
 fuse
 
+# OpenVPN
+openvpn
+NetworkManager-openvpn
+
 ### space issues
 -ktorrent			# kget has also basic torrent features (~3 megs)
 -digikam			# digikam has duplicate functionality with gwenview (~28 megs)

--- a/kickstarts/10-kitten/x86_64/almalinux-live-kde.ks
+++ b/kickstarts/10-kitten/x86_64/almalinux-live-kde.ks
@@ -20,6 +20,7 @@ repo --name="appstream" --baseurl=https://kitten.repo.almalinux.org/10-kitten/Ap
 repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extras-common/$basearch/os/
 repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/$basearch/os/
 repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
+repo --name="anaconda-albs" --baseurl=https://build.almalinux.org/pulp/content/builds/AlmaLinux-Kitten-10-x86_64-25058-br/
 
 # Firewall configuration
 firewall --enabled --service=mdns
@@ -197,8 +198,7 @@ kernel-modules-extra
 # The point of a live image is to install
 anaconda
 anaconda-install-env-deps
-# TODO: "Install to Hard Drive" temporary disabled because of https://github.com/rhinstaller/anaconda/discussions/5997
-#anaconda-live
+anaconda-live
 @anaconda-tools
 # Anaconda has a weak dep on this and we don't want it on livecds, see
 # https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD

--- a/kickstarts/10-kitten/x86_64/almalinux-live-kde.ks
+++ b/kickstarts/10-kitten/x86_64/almalinux-live-kde.ks
@@ -21,7 +21,6 @@ repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extra
 repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/$basearch/os/
 repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
 repo --name="anaconda-albs" --baseurl=https://build.almalinux.org/pulp/content/builds/AlmaLinux-Kitten-10-x86_64-25058-br/
-repo --name="almalinux-backgrounds-extras" --baseurl=https://build.almalinux.org/pulp/content/builds/AlmaLinux-Kitten-10-x86_64-25225-br/
 
 # Firewall configuration
 firewall --enabled --service=mdns
@@ -96,6 +95,15 @@ cat <<'EOF'>/home/liveuser/.config/kscreenlockerrc
 Image=/usr/share/wallpapers/Alma-default/
 PreviewImage=/usr/share/wallpapers/Alma-default/
 EOF
+# Replace live installer icon for the application and welcome center
+cd /usr/share/icons
+anaconda_installer_icon=org.fedoraproject.AnacondaInstaller.svg
+sed -i "s/Icon=.*$/Icon=\/usr\/share\/icons\/hicolor\/scalable\/apps\/${anaconda_installer_icon}/g" \
+  /usr/share/applications/liveinst.desktop
+almalinux_installer_icon=../../../hicolor/scalable/apps/${anaconda_installer_icon}
+ln -sf ${almalinux_installer_icon} breeze/apps/48/${anaconda_installer_icon}
+ln -sf ${almalinux_installer_icon} breeze-dark/apps/48/${anaconda_installer_icon}
+cd - >/dev/null
 
 # Disable network service here, as doing it in the services line
 # fails due to RHBZ #1369794

--- a/kickstarts/10-kitten/x86_64/almalinux-live-kde.ks
+++ b/kickstarts/10-kitten/x86_64/almalinux-live-kde.ks
@@ -21,6 +21,7 @@ repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extra
 repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/$basearch/os/
 repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
 repo --name="anaconda-albs" --baseurl=https://build.almalinux.org/pulp/content/builds/AlmaLinux-Kitten-10-x86_64-25058-br/
+repo --name="almalinux-backgrounds-extras" --baseurl=https://build.almalinux.org/pulp/content/builds/AlmaLinux-Kitten-10-x86_64-25225-br/
 
 # Firewall configuration
 firewall --enabled --service=mdns
@@ -85,63 +86,16 @@ echo 'File created by kickstart. See systemd-update-done.service(8).' \
 # See bug 1317709
 rm -f /boot/*-rescue*
 
-# TODO: almalinux-backgrounds-extras package looks good, remove inline method
-# on next build
-generateKDEWallpapers() {
-  # Declare an array for background types
-  declare -a bgtypes=("dark" "light" "abstract-dark" "abstract-light" "mountains-dark" "mountains-white" "waves-dark" "waves-light" "waves-sunset")
-  # Declare an array for background sizes
-  declare -a sizes=("1800x1440.jpg" "2048x1536.jpg" "2560x1080.jpg" "2560x1440.jpg" "2560x1600.jpg" "3440x1440.jpg")
-  ## Loop through the above array(s) types and sizes to create links and metadata
-  for bg in "${bgtypes[@]}"
-  do
-    echo "Processing 'Alma-"$bg"' background"
-    # Remove any old folders and create new structure
-    rm -rf /usr/share/wallpapers/Alma-$bg*
-    mkdir -p /usr/share/wallpapers/Alma-$bg/contents/images/
-    # creae sym link for all sizes
-    for size in "${sizes[@]}"
-    do
-    ln -s /usr/share/backgrounds/Alma-$bg-$size /usr/share/wallpapers/Alma-$bg/contents/images/$size
-    done
-    # Create metadata file to make Desktop Wallpaper application happy
-    # Move this to pre-created files in repo to give support to other languages
-    # This is quick hack for time being.
-    cat > /usr/share/wallpapers/Alma-$bg/metadata.desktop <<FOE
-[Desktop Entry]
-Name=AlmaLinux $bg
-
-X-KDE-PluginInfo-Author=Bala Raman
-X-KDE-PluginInfo-Email=srbala@gmail.com
-X-KDE-PluginInfo-Name=Alma-$bg
-X-KDE-PluginInfo-Version=0.1.0
-X-KDE-PluginInfo-Website=https://almalinux.org
-X-KDE-PluginInfo-Category=
-X-KDE-PluginInfo-Depends=
-X-KDE-PluginInfo-License=CC-BY-SA
-X-KDE-PluginInfo-EnabledByDefault=true
-X-Plasma-API=5.0
-
-FOE
-  done
-}
-# call function to create wallpapers
-# generateKDEWallpapers
-# Very ODD fix to get Alma background, find alternative
-rm -rf /usr/share/wallpapers/Fedora
-ln -s Alma-mountains-white /usr/share/wallpapers/Fedora
-# background end
-
-# Update default theme - this has to stay KS
-# Hack KDE Fedora package starts. TODO: need almalinux-kde-fix package
-sed -i 's/defaultWallpaperTheme=Fedora/defaultWallpaperTheme=Alma-mountains-white/' /usr/share/plasma/desktoptheme/default/metadata.desktop
-sed -i 's/defaultFileSuffix=.png/defaultFileSuffix=.jpg/' /usr/share/plasma/desktoptheme/default/metadata.desktop
-sed -i 's/defaultWidth=1920/defaultWidth=2048/' /usr/share/plasma/desktoptheme/default/metadata.desktop
-sed -i 's/defaultHeight=1080/defaultHeight=1536/' /usr/share/plasma/desktoptheme/default/metadata.desktop
-# Update KInfocenter
-sed -i 's/pixmaps\/system-logo-white.png/icons\/hicolor\/256x256\/apps\/fedora-logo-icon.png/' /etc/xdg/kcm-about-distrorc
-sed -i 's/http:\/\/fedoraproject.org/https:\/\/almalinux.org/' /etc/xdg/kcm-about-distrorc
-# Hack KDE Fedora package ends
+# Theme wallpapers
+rm -f /usr/share/wallpapers/Fedora
+ln -s Alma-default /usr/share/wallpapers/Fedora
+# Locked screen wallpapers
+mkdir -p /home/liveuser/.config && chown -R liveuser:liveuser /home/liveuser/.config
+cat <<'EOF'>/home/liveuser/.config/kscreenlockerrc
+[Greeter][Wallpaper][org.kde.image][General]
+Image=/usr/share/wallpapers/Alma-default/
+PreviewImage=/usr/share/wallpapers/Alma-default/
+EOF
 
 # Disable network service here, as doing it in the services line
 # fails due to RHBZ #1369794

--- a/kickstarts/10-kitten/x86_64/almalinux-live-kde.ks
+++ b/kickstarts/10-kitten/x86_64/almalinux-live-kde.ks
@@ -95,14 +95,8 @@ Image=/usr/share/wallpapers/Alma-default/
 PreviewImage=/usr/share/wallpapers/Alma-default/
 EOF
 # Replace live installer icon for the application and welcome center
-cd /usr/share/icons
-anaconda_installer_icon=org.fedoraproject.AnacondaInstaller.svg
-sed -i "s/Icon=.*$/Icon=\/usr\/share\/icons\/hicolor\/scalable\/apps\/${anaconda_installer_icon}/g" \
+sed -i "s/Icon=.*$/Icon=\/usr\/share\/icons\/hicolor\/scalable\/apps\/org.fedoraproject.AnacondaInstaller.svg/g" \
   /usr/share/applications/liveinst.desktop
-almalinux_installer_icon=../../../hicolor/scalable/apps/${anaconda_installer_icon}
-ln -sf ${almalinux_installer_icon} breeze/apps/48/${anaconda_installer_icon}
-ln -sf ${almalinux_installer_icon} breeze-dark/apps/48/${anaconda_installer_icon}
-cd - >/dev/null
 
 # Disable network service here, as doing it in the services line
 # fails due to RHBZ #1369794

--- a/kickstarts/10-kitten/x86_64/almalinux-live-kde.ks
+++ b/kickstarts/10-kitten/x86_64/almalinux-live-kde.ks
@@ -20,7 +20,6 @@ repo --name="appstream" --baseurl=https://kitten.repo.almalinux.org/10-kitten/Ap
 repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extras-common/$basearch/os/
 repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/$basearch/os/
 repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
-repo --name="anaconda-albs" --baseurl=https://build.almalinux.org/pulp/content/builds/AlmaLinux-Kitten-10-x86_64-25058-br/
 
 # Firewall configuration
 firewall --enabled --service=mdns

--- a/kickstarts/10-kitten/x86_64_v2/almalinux-live-gnome-mini.ks
+++ b/kickstarts/10-kitten/x86_64_v2/almalinux-live-gnome-mini.ks
@@ -147,9 +147,9 @@ firefox
 @gnome-desktop
 
 # OpenVPN
-#openvpn
-#NetworkManager-openvpn
-#NetworkManager-openvpn-gnome
+# openvpn
+# NetworkManager-openvpn
+# NetworkManager-openvpn-gnome
 
 # Exclude unwanted packages from @anaconda-tools group
 -gfs2-utils

--- a/kickstarts/10-kitten/x86_64_v2/almalinux-live-gnome-mini.ks
+++ b/kickstarts/10-kitten/x86_64_v2/almalinux-live-gnome-mini.ks
@@ -17,7 +17,7 @@ url --url=https://kitten.repo.almalinux.org/10-kitten/BaseOS/x86_64_v2/os/
 repo --name="appstream" --baseurl=https://kitten.repo.almalinux.org/10-kitten/AppStream/x86_64_v2/os/
 repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extras-common/x86_64_v2/os/
 repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/x86_64_v2/os/
-
+repo --name="anaconda-albs" --baseurl=https://build.almalinux.org/pulp/content/builds/AlmaLinux-Kitten-10-x86_64_v2-25058-br/
 
 # Network information
 network --activate --bootproto=dhcp --device=link --onboot=on
@@ -111,8 +111,7 @@ kernel-modules-extra
 # The point of a live image is to install
 anaconda
 anaconda-install-env-deps
-# TODO: "Install to Hard Drive" temporary disabled because of https://github.com/rhinstaller/anaconda/discussions/5997
-#anaconda-live
+anaconda-live
 @anaconda-tools
 # Anaconda has a weak dep on this and we don't want it on livecds, see
 # https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD

--- a/kickstarts/10-kitten/x86_64_v2/almalinux-live-gnome-mini.ks
+++ b/kickstarts/10-kitten/x86_64_v2/almalinux-live-gnome-mini.ks
@@ -17,7 +17,6 @@ url --url=https://kitten.repo.almalinux.org/10-kitten/BaseOS/x86_64_v2/os/
 repo --name="appstream" --baseurl=https://kitten.repo.almalinux.org/10-kitten/AppStream/x86_64_v2/os/
 repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extras-common/x86_64_v2/os/
 repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/x86_64_v2/os/
-repo --name="anaconda-albs" --baseurl=https://build.almalinux.org/pulp/content/builds/AlmaLinux-Kitten-10-x86_64_v2-25058-br/
 
 # Network information
 network --activate --bootproto=dhcp --device=link --onboot=on

--- a/kickstarts/10-kitten/x86_64_v2/almalinux-live-gnome.ks
+++ b/kickstarts/10-kitten/x86_64_v2/almalinux-live-gnome.ks
@@ -167,9 +167,9 @@ uresourced
 whois
 
 # OpenVPN
-#openvpn
-#NetworkManager-openvpn
-#NetworkManager-openvpn-gnome
+# openvpn
+# NetworkManager-openvpn
+# NetworkManager-openvpn-gnome
 
 # minimization
 -hplip

--- a/kickstarts/10-kitten/x86_64_v2/almalinux-live-gnome.ks
+++ b/kickstarts/10-kitten/x86_64_v2/almalinux-live-gnome.ks
@@ -17,7 +17,6 @@ url --url=https://kitten.repo.almalinux.org/10-kitten/BaseOS/x86_64_v2/os/
 repo --name="appstream" --baseurl=https://kitten.repo.almalinux.org/10-kitten/AppStream/x86_64_v2/os/
 repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extras-common/x86_64_v2/os/
 repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/x86_64_v2/os/
-repo --name="anaconda-albs" --baseurl=https://build.almalinux.org/pulp/content/builds/AlmaLinux-Kitten-10-x86_64_v2-25058-br/
 
 # Network information
 network --activate --bootproto=dhcp --device=link --onboot=on

--- a/kickstarts/10-kitten/x86_64_v2/almalinux-live-gnome.ks
+++ b/kickstarts/10-kitten/x86_64_v2/almalinux-live-gnome.ks
@@ -17,6 +17,7 @@ url --url=https://kitten.repo.almalinux.org/10-kitten/BaseOS/x86_64_v2/os/
 repo --name="appstream" --baseurl=https://kitten.repo.almalinux.org/10-kitten/AppStream/x86_64_v2/os/
 repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extras-common/x86_64_v2/os/
 repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/x86_64_v2/os/
+repo --name="anaconda-albs" --baseurl=https://build.almalinux.org/pulp/content/builds/AlmaLinux-Kitten-10-x86_64_v2-25058-br/
 
 # Network information
 network --activate --bootproto=dhcp --device=link --onboot=on
@@ -110,8 +111,7 @@ kernel-modules-extra
 # The point of a live image is to install
 anaconda
 anaconda-install-env-deps
-# TODO: "Install to Hard Drive" temporary disabled because of https://github.com/rhinstaller/anaconda/discussions/5997
-#anaconda-live
+anaconda-live
 @anaconda-tools
 # Anaconda has a weak dep on this and we don't want it on livecds, see
 # https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD

--- a/kickstarts/10/aarch64/almalinux-live-gnome-mini.ks
+++ b/kickstarts/10/aarch64/almalinux-live-gnome-mini.ks
@@ -155,9 +155,9 @@ firefox
 @gnome-desktop
 
 # OpenVPN
-#openvpn
-#NetworkManager-openvpn
-#NetworkManager-openvpn-gnome
+openvpn
+NetworkManager-openvpn
+NetworkManager-openvpn-gnome
 
 # Exclude unwanted packages from @anaconda-tools group
 -gfs2-utils

--- a/kickstarts/10/aarch64/almalinux-live-gnome.ks
+++ b/kickstarts/10/aarch64/almalinux-live-gnome.ks
@@ -190,9 +190,9 @@ uresourced
 whois
 
 # OpenVPN
-#openvpn
-#NetworkManager-openvpn
-#NetworkManager-openvpn-gnome
+openvpn
+NetworkManager-openvpn
+NetworkManager-openvpn-gnome
 
 # minimization
 -hplip

--- a/kickstarts/10/aarch64/almalinux-live-kde.ks
+++ b/kickstarts/10/aarch64/almalinux-live-kde.ks
@@ -200,6 +200,10 @@ firefox
 # Additional packages that are not default in kde-* groups, but useful
 fuse
 
+# OpenVPN
+openvpn
+NetworkManager-openvpn
+
 ### space issues
 -ktorrent			# kget has also basic torrent features (~3 megs)
 -digikam			# digikam has duplicate functionality with gwenview (~28 megs)

--- a/kickstarts/10/aarch64/almalinux-live-kde.ks
+++ b/kickstarts/10/aarch64/almalinux-live-kde.ks
@@ -88,63 +88,16 @@ echo 'File created by kickstart. See systemd-update-done.service(8).' \
 # See bug 1317709
 rm -f /boot/*-rescue*
 
-# TODO: almalinux-backgrounds-extras package looks good, remove inline method
-# on next build
-generateKDEWallpapers() {
-  # Declare an array for background types
-  declare -a bgtypes=("dark" "light" "abstract-dark" "abstract-light" "mountains-dark" "mountains-white" "waves-dark" "waves-light" "waves-sunset")
-  # Declare an array for background sizes
-  declare -a sizes=("1800x1440.jpg" "2048x1536.jpg" "2560x1080.jpg" "2560x1440.jpg" "2560x1600.jpg" "3440x1440.jpg")
-  ## Loop through the above array(s) types and sizes to create links and metadata
-  for bg in "${bgtypes[@]}"
-  do
-    echo "Processing 'Alma-"$bg"' background"
-    # Remove any old folders and create new structure
-    rm -rf /usr/share/wallpapers/Alma-$bg*
-    mkdir -p /usr/share/wallpapers/Alma-$bg/contents/images/
-    # creae sym link for all sizes
-    for size in "${sizes[@]}"
-    do
-    ln -s /usr/share/backgrounds/Alma-$bg-$size /usr/share/wallpapers/Alma-$bg/contents/images/$size
-    done
-    # Create metadata file to make Desktop Wallpaper application happy
-    # Move this to pre-created files in repo to give support to other languages
-    # This is quick hack for time being.
-    cat > /usr/share/wallpapers/Alma-$bg/metadata.desktop <<FOE
-[Desktop Entry]
-Name=AlmaLinux $bg
-
-X-KDE-PluginInfo-Author=Bala Raman
-X-KDE-PluginInfo-Email=srbala@gmail.com
-X-KDE-PluginInfo-Name=Alma-$bg
-X-KDE-PluginInfo-Version=0.1.0
-X-KDE-PluginInfo-Website=https://almalinux.org
-X-KDE-PluginInfo-Category=
-X-KDE-PluginInfo-Depends=
-X-KDE-PluginInfo-License=CC-BY-SA
-X-KDE-PluginInfo-EnabledByDefault=true
-X-Plasma-API=5.0
-
-FOE
-  done
-}
-# call function to create wallpapers
-# generateKDEWallpapers
-# Very ODD fix to get Alma background, find alternative
-rm -rf /usr/share/wallpapers/Fedora
-ln -s Alma-mountains-white /usr/share/wallpapers/Fedora
-# background end
-
-# Update default theme - this has to stay KS
-# Hack KDE Fedora package starts. TODO: need almalinux-kde-fix package
-sed -i 's/defaultWallpaperTheme=Fedora/defaultWallpaperTheme=Alma-mountains-white/' /usr/share/plasma/desktoptheme/default/metadata.desktop
-sed -i 's/defaultFileSuffix=.png/defaultFileSuffix=.jpg/' /usr/share/plasma/desktoptheme/default/metadata.desktop
-sed -i 's/defaultWidth=1920/defaultWidth=2048/' /usr/share/plasma/desktoptheme/default/metadata.desktop
-sed -i 's/defaultHeight=1080/defaultHeight=1536/' /usr/share/plasma/desktoptheme/default/metadata.desktop
-# Update KInfocenter
-sed -i 's/pixmaps\/system-logo-white.png/icons\/hicolor\/256x256\/apps\/fedora-logo-icon.png/' /etc/xdg/kcm-about-distrorc
-sed -i 's/http:\/\/fedoraproject.org/https:\/\/almalinux.org/' /etc/xdg/kcm-about-distrorc
-# Hack KDE Fedora package ends
+# Theme wallpapers
+rm -f /usr/share/wallpapers/Fedora
+ln -s Alma-default /usr/share/wallpapers/Fedora
+# Locked screen wallpapers
+mkdir -p /home/liveuser/.config && chown -R liveuser:liveuser /home/liveuser/.config
+cat <<'EOF'>/home/liveuser/.config/kscreenlockerrc
+[Greeter][Wallpaper][org.kde.image][General]
+Image=/usr/share/wallpapers/Alma-default/
+PreviewImage=/usr/share/wallpapers/Alma-default/
+EOF
 
 # Disable network service here, as doing it in the services line
 # fails due to RHBZ #1369794

--- a/kickstarts/10/aarch64/almalinux-live-kde.ks
+++ b/kickstarts/10/aarch64/almalinux-live-kde.ks
@@ -99,14 +99,8 @@ Image=/usr/share/wallpapers/Alma-default/
 PreviewImage=/usr/share/wallpapers/Alma-default/
 EOF
 # Replace live installer icon for the application and welcome center
-cd /usr/share/icons
-anaconda_installer_icon=org.fedoraproject.AnacondaInstaller.svg
-sed -i "s/Icon=.*$/Icon=\/usr\/share\/icons\/hicolor\/scalable\/apps\/${anaconda_installer_icon}/g" \
+sed -i "s/Icon=.*$/Icon=\/usr\/share\/icons\/hicolor\/scalable\/apps\/org.fedoraproject.AnacondaInstaller.svg/g" \
   /usr/share/applications/liveinst.desktop
-almalinux_installer_icon=../../../hicolor/scalable/apps/${anaconda_installer_icon}
-ln -sf ${almalinux_installer_icon} breeze/apps/48/${anaconda_installer_icon}
-ln -sf ${almalinux_installer_icon} breeze-dark/apps/48/${anaconda_installer_icon}
-cd - >/dev/null
 
 # Disable network service here, as doing it in the services line
 # fails due to RHBZ #1369794

--- a/kickstarts/10/aarch64/almalinux-live-kde.ks
+++ b/kickstarts/10/aarch64/almalinux-live-kde.ks
@@ -98,6 +98,15 @@ cat <<'EOF'>/home/liveuser/.config/kscreenlockerrc
 Image=/usr/share/wallpapers/Alma-default/
 PreviewImage=/usr/share/wallpapers/Alma-default/
 EOF
+# Replace live installer icon for the application and welcome center
+cd /usr/share/icons
+anaconda_installer_icon=org.fedoraproject.AnacondaInstaller.svg
+sed -i "s/Icon=.*$/Icon=\/usr\/share\/icons\/hicolor\/scalable\/apps\/${anaconda_installer_icon}/g" \
+  /usr/share/applications/liveinst.desktop
+almalinux_installer_icon=../../../hicolor/scalable/apps/${anaconda_installer_icon}
+ln -sf ${almalinux_installer_icon} breeze/apps/48/${anaconda_installer_icon}
+ln -sf ${almalinux_installer_icon} breeze-dark/apps/48/${anaconda_installer_icon}
+cd - >/dev/null
 
 # Disable network service here, as doing it in the services line
 # fails due to RHBZ #1369794

--- a/kickstarts/10/x86_64/almalinux-live-gnome-mini.ks
+++ b/kickstarts/10/x86_64/almalinux-live-gnome-mini.ks
@@ -153,9 +153,9 @@ firefox
 @gnome-desktop
 
 # OpenVPN
-#openvpn
-#NetworkManager-openvpn
-#NetworkManager-openvpn-gnome
+openvpn
+NetworkManager-openvpn
+NetworkManager-openvpn-gnome
 
 # Exclude unwanted packages from @anaconda-tools group
 -gfs2-utils

--- a/kickstarts/10/x86_64/almalinux-live-gnome.ks
+++ b/kickstarts/10/x86_64/almalinux-live-gnome.ks
@@ -171,9 +171,9 @@ uresourced
 whois
 
 # OpenVPN
-#openvpn
-#NetworkManager-openvpn
-#NetworkManager-openvpn-gnome
+openvpn
+NetworkManager-openvpn
+NetworkManager-openvpn-gnome
 
 # minimization
 -hplip

--- a/kickstarts/10/x86_64/almalinux-live-kde.ks
+++ b/kickstarts/10/x86_64/almalinux-live-kde.ks
@@ -203,6 +203,10 @@ firefox
 # Additional packages that are not default in kde-* groups, but useful
 fuse
 
+# OpenVPN
+openvpn
+NetworkManager-openvpn
+
 ### space issues
 -ktorrent			# kget has also basic torrent features (~3 megs)
 -digikam			# digikam has duplicate functionality with gwenview (~28 megs)

--- a/kickstarts/10/x86_64/almalinux-live-kde.ks
+++ b/kickstarts/10/x86_64/almalinux-live-kde.ks
@@ -88,63 +88,16 @@ echo 'File created by kickstart. See systemd-update-done.service(8).' \
 # See bug 1317709
 rm -f /boot/*-rescue*
 
-# TODO: almalinux-backgrounds-extras package looks good, remove inline method
-# on next build
-generateKDEWallpapers() {
-  # Declare an array for background types
-  declare -a bgtypes=("dark" "light" "abstract-dark" "abstract-light" "mountains-dark" "mountains-white" "waves-dark" "waves-light" "waves-sunset")
-  # Declare an array for background sizes
-  declare -a sizes=("1800x1440.jpg" "2048x1536.jpg" "2560x1080.jpg" "2560x1440.jpg" "2560x1600.jpg" "3440x1440.jpg")
-  ## Loop through the above array(s) types and sizes to create links and metadata
-  for bg in "${bgtypes[@]}"
-  do
-    echo "Processing 'Alma-"$bg"' background"
-    # Remove any old folders and create new structure
-    rm -rf /usr/share/wallpapers/Alma-$bg*
-    mkdir -p /usr/share/wallpapers/Alma-$bg/contents/images/
-    # creae sym link for all sizes
-    for size in "${sizes[@]}"
-    do
-    ln -s /usr/share/backgrounds/Alma-$bg-$size /usr/share/wallpapers/Alma-$bg/contents/images/$size
-    done
-    # Create metadata file to make Desktop Wallpaper application happy
-    # Move this to pre-created files in repo to give support to other languages
-    # This is quick hack for time being.
-    cat > /usr/share/wallpapers/Alma-$bg/metadata.desktop <<FOE
-[Desktop Entry]
-Name=AlmaLinux $bg
-
-X-KDE-PluginInfo-Author=Bala Raman
-X-KDE-PluginInfo-Email=srbala@gmail.com
-X-KDE-PluginInfo-Name=Alma-$bg
-X-KDE-PluginInfo-Version=0.1.0
-X-KDE-PluginInfo-Website=https://almalinux.org
-X-KDE-PluginInfo-Category=
-X-KDE-PluginInfo-Depends=
-X-KDE-PluginInfo-License=CC-BY-SA
-X-KDE-PluginInfo-EnabledByDefault=true
-X-Plasma-API=5.0
-
-FOE
-  done
-}
-# call function to create wallpapers
-# generateKDEWallpapers
-# Very ODD fix to get Alma background, find alternative
-rm -rf /usr/share/wallpapers/Fedora
-ln -s Alma-mountains-white /usr/share/wallpapers/Fedora
-# background end
-
-# Update default theme - this has to stay KS
-# Hack KDE Fedora package starts. TODO: need almalinux-kde-fix package
-sed -i 's/defaultWallpaperTheme=Fedora/defaultWallpaperTheme=Alma-mountains-white/' /usr/share/plasma/desktoptheme/default/metadata.desktop
-sed -i 's/defaultFileSuffix=.png/defaultFileSuffix=.jpg/' /usr/share/plasma/desktoptheme/default/metadata.desktop
-sed -i 's/defaultWidth=1920/defaultWidth=2048/' /usr/share/plasma/desktoptheme/default/metadata.desktop
-sed -i 's/defaultHeight=1080/defaultHeight=1536/' /usr/share/plasma/desktoptheme/default/metadata.desktop
-# Update KInfocenter
-sed -i 's/pixmaps\/system-logo-white.png/icons\/hicolor\/256x256\/apps\/fedora-logo-icon.png/' /etc/xdg/kcm-about-distrorc
-sed -i 's/http:\/\/fedoraproject.org/https:\/\/almalinux.org/' /etc/xdg/kcm-about-distrorc
-# Hack KDE Fedora package ends
+# Theme wallpapers
+rm -f /usr/share/wallpapers/Fedora
+ln -s Alma-default /usr/share/wallpapers/Fedora
+# Locked screen wallpapers
+mkdir -p /home/liveuser/.config && chown -R liveuser:liveuser /home/liveuser/.config
+cat <<'EOF'>/home/liveuser/.config/kscreenlockerrc
+[Greeter][Wallpaper][org.kde.image][General]
+Image=/usr/share/wallpapers/Alma-default/
+PreviewImage=/usr/share/wallpapers/Alma-default/
+EOF
 
 # Disable network service here, as doing it in the services line
 # fails due to RHBZ #1369794

--- a/kickstarts/10/x86_64/almalinux-live-kde.ks
+++ b/kickstarts/10/x86_64/almalinux-live-kde.ks
@@ -99,14 +99,8 @@ Image=/usr/share/wallpapers/Alma-default/
 PreviewImage=/usr/share/wallpapers/Alma-default/
 EOF
 # Replace live installer icon for the application and welcome center
-cd /usr/share/icons
-anaconda_installer_icon=org.fedoraproject.AnacondaInstaller.svg
-sed -i "s/Icon=.*$/Icon=\/usr\/share\/icons\/hicolor\/scalable\/apps\/${anaconda_installer_icon}/g" \
+sed -i "s/Icon=.*$/Icon=\/usr\/share\/icons\/hicolor\/scalable\/apps\/org.fedoraproject.AnacondaInstaller.svg/g" \
   /usr/share/applications/liveinst.desktop
-almalinux_installer_icon=../../../hicolor/scalable/apps/${anaconda_installer_icon}
-ln -sf ${almalinux_installer_icon} breeze/apps/48/${anaconda_installer_icon}
-ln -sf ${almalinux_installer_icon} breeze-dark/apps/48/${anaconda_installer_icon}
-cd - >/dev/null
 
 # Disable network service here, as doing it in the services line
 # fails due to RHBZ #1369794

--- a/kickstarts/10/x86_64/almalinux-live-kde.ks
+++ b/kickstarts/10/x86_64/almalinux-live-kde.ks
@@ -98,6 +98,15 @@ cat <<'EOF'>/home/liveuser/.config/kscreenlockerrc
 Image=/usr/share/wallpapers/Alma-default/
 PreviewImage=/usr/share/wallpapers/Alma-default/
 EOF
+# Replace live installer icon for the application and welcome center
+cd /usr/share/icons
+anaconda_installer_icon=org.fedoraproject.AnacondaInstaller.svg
+sed -i "s/Icon=.*$/Icon=\/usr\/share\/icons\/hicolor\/scalable\/apps\/${anaconda_installer_icon}/g" \
+  /usr/share/applications/liveinst.desktop
+almalinux_installer_icon=../../../hicolor/scalable/apps/${anaconda_installer_icon}
+ln -sf ${almalinux_installer_icon} breeze/apps/48/${anaconda_installer_icon}
+ln -sf ${almalinux_installer_icon} breeze-dark/apps/48/${anaconda_installer_icon}
+cd - >/dev/null
 
 # Disable network service here, as doing it in the services line
 # fails due to RHBZ #1369794

--- a/kickstarts/10/x86_64_v2/almalinux-live-gnome-mini.ks
+++ b/kickstarts/10/x86_64_v2/almalinux-live-gnome-mini.ks
@@ -152,9 +152,9 @@ firefox
 @gnome-desktop
 
 # OpenVPN
-#openvpn
-#NetworkManager-openvpn
-#NetworkManager-openvpn-gnome
+# openvpn
+# NetworkManager-openvpn
+# NetworkManager-openvpn-gnome
 
 # Exclude unwanted packages from @anaconda-tools group
 -gfs2-utils

--- a/kickstarts/10/x86_64_v2/almalinux-live-gnome.ks
+++ b/kickstarts/10/x86_64_v2/almalinux-live-gnome.ks
@@ -171,9 +171,9 @@ uresourced
 whois
 
 # OpenVPN
-#openvpn
-#NetworkManager-openvpn
-#NetworkManager-openvpn-gnome
+# openvpn
+# NetworkManager-openvpn
+# NetworkManager-openvpn-gnome
 
 # minimization
 -hplip


### PR DESCRIPTION
- Install OpenVPN into GNOME, Mini, KDE; x86_64 (v3 only) and aarch64
- KDE: set AlmaLinux wallpapers, replace live installer icon for the application and welcome center

- Enable "Install to Hard Drive" functionality for Kitten 10