### PR TITLE
AlmaLinux release 10.0 Live Images

### DIFF
--- a/.github/workflows/build-media.yml
+++ b/.github/workflows/build-media.yml
@@ -112,6 +112,12 @@ jobs:
           # TODO: the excludes below should be removed when '10' provides need packages
           - version: 10
             arch: x86_64_v2
+            image_type: GNOME
+          - version: 10
+            arch: x86_64_v2
+            image_type: GNOME-Mini
+          - version: 10
+            arch: x86_64_v2
             image_type: KDE
           - version: 10
             arch: x86_64_v2
@@ -126,9 +132,6 @@ jobs:
           - version: 10-kitten
             arch: x86_64
             image_type: XFCE
-          - version: 10
-            arch: x86_64
-            image_type: KDE
           - version: 10
             arch: x86_64
             image_type: MATE
@@ -257,9 +260,6 @@ jobs:
             image_type: XFCE
           - version: 10
             arch: aarch64
-            image_type: KDE
-          - version: 10
-            arch: aarch64
             image_type: MATE
           - version: 10
             arch: aarch64
@@ -312,9 +312,6 @@ jobs:
           - version: 10-kitten
             arch: aarch64
             image_type: XFCE
-          - version: 10
-            arch: aarch64
-            image_type: KDE
           - version: 10
             arch: aarch64
             image_type: MATE

--- a/kickstarts/10/aarch64/almalinux-live-gnome-mini.ks
+++ b/kickstarts/10/aarch64/almalinux-live-gnome-mini.ks
@@ -13,16 +13,11 @@ lang en_US.UTF-8
 firewall --enabled --service=mdns
 
 # Repos
-# url --url=https://repo.almalinux.org/almalinux/10/BaseOS/$basearch/os/
-url --url=https://vault.almalinux.org/10.0-beta/BaseOS/$basearch/os/
-# repo --name="appstream" --baseurl=https://repo.almalinux.org/almalinux/10/AppStream/$basearch/os/
-repo --name="appstream" --baseurl=https://vault.almalinux.org/10.0-beta/AppStream/$basearch/os/
-# repo --name="extras" --baseurl=https://repo.almalinux.org/almalinux/10/extras/$basearch/os/
-repo --name="extras" --baseurl=https://vault.almalinux.org/10.0-beta/extras/$basearch/os/
-# repo --name="crb" --baseurl=https://repo.almalinux.org/almalinux/10/CRB/$basearch/os/
-repo --name="crb" --baseurl=https://vault.almalinux.org/10.0-beta/CRB/$basearch/os/
-repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
-
+url --url=https://repo.almalinux.org/almalinux/10/BaseOS/$basearch/os/
+repo --name="appstream" --baseurl=https://repo.almalinux.org/almalinux/10/AppStream/$basearch/os/
+repo --name="extras" --baseurl=https://repo.almalinux.org/almalinux/10/extras/$basearch/os/
+repo --name="crb" --baseurl=https://repo.almalinux.org/almalinux/10/CRB/$basearch/os/
+repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10z/Everything/$basearch/
 
 # Network information
 network --activate --bootproto=dhcp --device=link --onboot=on
@@ -104,6 +99,9 @@ getent passwd openvpn &>/dev/null || \
     /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
         -d /etc/openvpn openvpn
 
+# TODO: To place Firefox into Task Manager
+# This should be removed when upstream fixes the livesys-scripts package
+sed -i  's/org.mozilla.firefox.desktop/firefox.desktop/g' /usr/libexec/livesys/sessions.d/livesys-gnome
 %end
 
 # Packages
@@ -116,7 +114,6 @@ kernel-modules-extra
 # The point of a live image is to install
 anaconda
 anaconda-install-env-deps
-# TODO: "Install to Hard Drive" temporary disabled because of https://github.com/rhinstaller/anaconda/discussions/5997
 anaconda-live
 @anaconda-tools
 # Anaconda has a weak dep on this and we don't want it on livecds, see

--- a/kickstarts/10/aarch64/almalinux-live-gnome.ks
+++ b/kickstarts/10/aarch64/almalinux-live-gnome.ks
@@ -13,15 +13,11 @@ lang en_US.UTF-8
 firewall --enabled --service=mdns
 
 # Repos
-# url --url=https://repo.almalinux.org/almalinux/10/BaseOS/$basearch/os/
-url --url=https://vault.almalinux.org/10.0-beta/BaseOS/$basearch/os/
-# repo --name="appstream" --baseurl=https://repo.almalinux.org/almalinux/10/AppStream/$basearch/os/
-repo --name="appstream" --baseurl=https://vault.almalinux.org/10.0-beta/AppStream/$basearch/os/
-# repo --name="extras" --baseurl=https://repo.almalinux.org/almalinux/10/extras/$basearch/os/
-repo --name="extras" --baseurl=https://vault.almalinux.org/10.0-beta/extras/$basearch/os/
-# repo --name="crb" --baseurl=https://repo.almalinux.org/almalinux/10/CRB/$basearch/os/
-repo --name="crb" --baseurl=https://vault.almalinux.org/10.0-beta/CRB/$basearch/os/
-repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
+url --url=https://repo.almalinux.org/almalinux/10/BaseOS/$basearch/os/
+repo --name="appstream" --baseurl=https://repo.almalinux.org/almalinux/10/AppStream/$basearch/os/
+repo --name="extras" --baseurl=https://repo.almalinux.org/almalinux/10/extras/$basearch/os/
+repo --name="crb" --baseurl=https://repo.almalinux.org/almalinux/10/CRB/$basearch/os/
+repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10z/Everything/$basearch/
 
 # Network information
 network --activate --bootproto=dhcp --device=link --onboot=on
@@ -103,6 +99,9 @@ getent passwd openvpn &>/dev/null || \
     /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
         -d /etc/openvpn openvpn
 
+# TODO: To place Firefox into Task Manager
+# This should be removed when upstream fixes the livesys-scripts package
+sed -i  's/org.mozilla.firefox.desktop/firefox.desktop/g' /usr/libexec/livesys/sessions.d/livesys-gnome
 %end
 
 # Packages
@@ -115,8 +114,7 @@ kernel-modules-extra
 # The point of a live image is to install
 anaconda
 anaconda-install-env-deps
-# TODO: "Install to Hard Drive" temporary disabled because of https://github.com/rhinstaller/anaconda/discussions/5997
-#anaconda-live
+anaconda-live
 @anaconda-tools
 # Anaconda has a weak dep on this and we don't want it on livecds, see
 # https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD

--- a/kickstarts/10/aarch64/almalinux-live-kde.ks
+++ b/kickstarts/10/aarch64/almalinux-live-kde.ks
@@ -15,15 +15,11 @@ timezone US/Eastern
 network  --bootproto=dhcp --device=link --activate
 
 # Repos
-# url --url=https://repo.almalinux.org/almalinux/10/BaseOS/$basearch/os/
-url --url=https://vault.almalinux.org/10.0-beta/BaseOS/$basearch/os/
-# repo --name="appstream" --baseurl=https://repo.almalinux.org/almalinux/10/AppStream/$basearch/os/
-repo --name="appstream" --baseurl=https://vault.almalinux.org/10.0-beta/AppStream/$basearch/os/
-# repo --name="extras" --baseurl=https://repo.almalinux.org/almalinux/10/extras-common/$basearch/os/
-repo --name="extras" --baseurl=https://vault.almalinux.org/10.0-beta/extras/$basearch/os/
-# repo --name="crb" --baseurl=https://repo.almalinux.org/almalinux/10/CRB/$basearch/os/
-repo --name="crb" --baseurl=https://vault.almalinux.org/10.0-beta/CRB/$basearch/os/
-repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
+url --url=https://repo.almalinux.org/almalinux/10/BaseOS/$basearch/os/
+repo --name="appstream" --baseurl=https://repo.almalinux.org/almalinux/10/AppStream/$basearch/os/
+repo --name="extras" --baseurl=https://repo.almalinux.org/almalinux/10/extras/$basearch/os/
+repo --name="crb" --baseurl=https://repo.almalinux.org/almalinux/10/CRB/$basearch/os/
+repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10z/Everything/$basearch/
 
 # Firewall configuration
 firewall --enabled --service=mdns
@@ -98,6 +94,11 @@ cat <<'EOF'>/home/liveuser/.config/kscreenlockerrc
 Image=/usr/share/wallpapers/Alma-default/
 PreviewImage=/usr/share/wallpapers/Alma-default/
 EOF
+# Login screen theme
+cat <<'EOF'>/etc/sddm.conf.d/kde_settings.conf
+[Theme]
+Current=breeze
+EOF
 # Replace live installer icon for the application and welcome center
 sed -i "s/Icon=.*$/Icon=\/usr\/share\/icons\/hicolor\/scalable\/apps\/org.fedoraproject.AnacondaInstaller.svg/g" \
   /usr/share/applications/liveinst.desktop
@@ -113,18 +114,6 @@ touch /etc/machine-id
 # set livesys session type
 sed -i 's/^livesys_session=.*/livesys_session="kde"/' /etc/sysconfig/livesys
 
-# set default GTK+ theme for root (see #683855, #689070, #808062)
-cat > /root/.gtkrc-2.0 << EOF
-include "/usr/share/themes/Adwaita/gtk-2.0/gtkrc"
-include "/etc/gtk-2.0/gtkrc"
-gtk-theme-name="Adwaita"
-EOF
-mkdir -p /root/.config/gtk-3.0
-cat > /root/.config/gtk-3.0/settings.ini << EOF
-[Settings]
-gtk-theme-name = Adwaita
-EOF
-
 # enable CRB repo
 dnf config-manager --enable crb
 
@@ -137,17 +126,6 @@ getent passwd openvpn &>/dev/null || \
 
 %end
 
-%post --nochroot
-# cp $INSTALL_ROOT/usr/share/licenses/*-release/* $LIVE_ROOT/
-
-# only works on x86_64
-# if [ "$(uname -m)" = "x86_64" ]; then
-#   if [ ! -d $LIVE_ROOT/LiveOS ]; then mkdir -p $LIVE_ROOT/LiveOS ; fi
-#   cp /usr/bin/livecd-iso-to-disk $LIVE_ROOT/LiveOS
-# fi
-
-%end
-
 %packages
 # Explicitly specified mandatory packages
 kernel
@@ -157,8 +135,7 @@ kernel-modules-extra
 # The point of a live image is to install
 anaconda
 anaconda-install-env-deps
-# TODO: "Install to Hard Drive" temporary disabled because of https://github.com/rhinstaller/anaconda/discussions/5997
-#anaconda-live
+anaconda-live
 @anaconda-tools
 # Anaconda has a weak dep on this and we don't want it on livecds, see
 # https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD

--- a/kickstarts/10/aarch64/almalinux-live-mate.ks
+++ b/kickstarts/10/aarch64/almalinux-live-mate.ks
@@ -19,7 +19,7 @@ url --url=https://repo.almalinux.org/almalinux/10/BaseOS/$basearch/os/
 repo --name="appstream" --baseurl=https://repo.almalinux.org/almalinux/10/AppStream/$basearch/os/
 repo --name="extras" --baseurl=https://repo.almalinux.org/almalinux/10/extras-common/$basearch/os/
 repo --name="crb" --baseurl=https://repo.almalinux.org/almalinux/10/CRB/$basearch/os/
-repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
+repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10z/Everything/$basearch/
 
 # Firewall configuration
 firewall --enabled --service=mdns

--- a/kickstarts/10/aarch64/almalinux-live-xfce.ks
+++ b/kickstarts/10/aarch64/almalinux-live-xfce.ks
@@ -19,7 +19,7 @@ url --url=https://repo.almalinux.org/almalinux/10/BaseOS/$basearch/os/
 repo --name="appstream" --baseurl=https://repo.almalinux.org/almalinux/10/AppStream/$basearch/os/
 repo --name="extras" --baseurl=https://repo.almalinux.org/almalinux/10/extras-common/$basearch/os/
 repo --name="crb" --baseurl=https://repo.almalinux.org/almalinux/10/CRB/$basearch/os/
-repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
+repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10z/Everything/$basearch/
 
 # Firewall configuration
 firewall --enabled --service=mdns
@@ -124,17 +124,6 @@ getent group openvpn &>/dev/null || groupadd -r openvpn
 getent passwd openvpn &>/dev/null || \
     /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
         -d /etc/openvpn openvpn
-
-%end
-
-%post --nochroot
-# cp $INSTALL_ROOT/usr/share/licenses/*-release/* $LIVE_ROOT/
-
-# only works on x86_64
-# if [ "$(uname -m)" = "x86_64" ]; then
-#   if [ ! -d $LIVE_ROOT/LiveOS ]; then mkdir -p $LIVE_ROOT/LiveOS ; fi
-#   cp /usr/bin/livecd-iso-to-disk $LIVE_ROOT/LiveOS
-# fi
 
 %end
 

--- a/kickstarts/10/x86_64/almalinux-live-gnome.ks
+++ b/kickstarts/10/x86_64/almalinux-live-gnome.ks
@@ -13,15 +13,11 @@ lang en_US.UTF-8
 firewall --enabled --service=mdns
 
 # Repos
-# url --url=https://repo.almalinux.org/almalinux/10/BaseOS/$basearch/os/
-url --url=https://vault.almalinux.org/10.0-beta/BaseOS/$basearch/os/
-# repo --name="appstream" --baseurl=https://repo.almalinux.org/almalinux/10/AppStream/$basearch/os/
-repo --name="appstream" --baseurl=https://vault.almalinux.org/10.0-beta/AppStream/$basearch/os/
-# repo --name="extras" --baseurl=https://repo.almalinux.org/almalinux/10/extras/$basearch/os/
-repo --name="extras" --baseurl=https://vault.almalinux.org/10.0-beta/extras/$basearch/os/
-# repo --name="crb" --baseurl=https://repo.almalinux.org/almalinux/10/CRB/$basearch/os/
-repo --name="crb" --baseurl=https://vault.almalinux.org/10.0-beta/CRB/$basearch/os/
-repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
+url --url=https://repo.almalinux.org/almalinux/10/BaseOS/$basearch/os/
+repo --name="appstream" --baseurl=https://repo.almalinux.org/almalinux/10/AppStream/$basearch/os/
+repo --name="extras" --baseurl=https://repo.almalinux.org/almalinux/10/extras/$basearch/os/
+repo --name="crb" --baseurl=https://repo.almalinux.org/almalinux/10/CRB/$basearch/os/
+repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10z/Everything/$basearch/
 
 # Network information
 network --activate --bootproto=dhcp --device=link --onboot=on
@@ -103,6 +99,9 @@ getent passwd openvpn &>/dev/null || \
     /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
         -d /etc/openvpn openvpn
 
+# TODO: To place Firefox into Task Manager
+# This should be removed when upstream fixes the livesys-scripts package
+sed -i  's/org.mozilla.firefox.desktop/firefox.desktop/g' /usr/libexec/livesys/sessions.d/livesys-gnome
 %end
 
 # Packages
@@ -115,8 +114,7 @@ kernel-modules-extra
 # The point of a live image is to install
 anaconda
 anaconda-install-env-deps
-# TODO: "Install to Hard Drive" temporary disabled because of https://github.com/rhinstaller/anaconda/discussions/5997
-#anaconda-live
+anaconda-live
 @anaconda-tools
 # Anaconda has a weak dep on this and we don't want it on livecds, see
 # https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD
@@ -148,7 +146,8 @@ firefox
 @^workstation-product-environment
 
 # GNOME specific
-@gnome-apps
+@gnome-desktop
+#@gnome-apps
 
 # Exclude unwanted packages from @anaconda-tools group
 -gfs2-utils

--- a/kickstarts/10/x86_64/almalinux-live-kde.ks
+++ b/kickstarts/10/x86_64/almalinux-live-kde.ks
@@ -15,15 +15,11 @@ timezone US/Eastern
 network  --bootproto=dhcp --device=link --activate
 
 # Repos
-# url --url=https://repo.almalinux.org/almalinux/10/BaseOS/$basearch/os/
-url --url=https://vault.almalinux.org/10.0-beta/BaseOS/$basearch/os/
-# repo --name="appstream" --baseurl=https://repo.almalinux.org/almalinux/10/AppStream/$basearch/os/
-repo --name="appstream" --baseurl=https://vault.almalinux.org/10.0-beta/AppStream/$basearch/os/
-# repo --name="extras" --baseurl=https://repo.almalinux.org/almalinux/10/extras-common/$basearch/os/
-repo --name="extras" --baseurl=https://vault.almalinux.org/10.0-beta/extras/$basearch/os/
-# repo --name="crb" --baseurl=https://repo.almalinux.org/almalinux/10/CRB/$basearch/os/
-repo --name="crb" --baseurl=https://vault.almalinux.org/10.0-beta/CRB/$basearch/os/
-repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
+url --url=https://repo.almalinux.org/almalinux/10/BaseOS/$basearch/os/
+repo --name="appstream" --baseurl=https://repo.almalinux.org/almalinux/10/AppStream/$basearch/os/
+repo --name="extras" --baseurl=https://repo.almalinux.org/almalinux/10/extras/$basearch/os/
+repo --name="crb" --baseurl=https://repo.almalinux.org/almalinux/10/CRB/$basearch/os/
+repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10z/Everything/$basearch/
 
 # Firewall configuration
 firewall --enabled --service=mdns
@@ -98,6 +94,11 @@ cat <<'EOF'>/home/liveuser/.config/kscreenlockerrc
 Image=/usr/share/wallpapers/Alma-default/
 PreviewImage=/usr/share/wallpapers/Alma-default/
 EOF
+# Login screen theme
+cat <<'EOF'>/etc/sddm.conf.d/kde_settings.conf
+[Theme]
+Current=breeze
+EOF
 # Replace live installer icon for the application and welcome center
 sed -i "s/Icon=.*$/Icon=\/usr\/share\/icons\/hicolor\/scalable\/apps\/org.fedoraproject.AnacondaInstaller.svg/g" \
   /usr/share/applications/liveinst.desktop
@@ -113,18 +114,6 @@ touch /etc/machine-id
 # set livesys session type
 sed -i 's/^livesys_session=.*/livesys_session="kde"/' /etc/sysconfig/livesys
 
-# set default GTK+ theme for root (see #683855, #689070, #808062)
-cat > /root/.gtkrc-2.0 << EOF
-include "/usr/share/themes/Adwaita/gtk-2.0/gtkrc"
-include "/etc/gtk-2.0/gtkrc"
-gtk-theme-name="Adwaita"
-EOF
-mkdir -p /root/.config/gtk-3.0
-cat > /root/.config/gtk-3.0/settings.ini << EOF
-[Settings]
-gtk-theme-name = Adwaita
-EOF
-
 # enable CRB repo
 dnf config-manager --enable crb
 
@@ -137,17 +126,6 @@ getent passwd openvpn &>/dev/null || \
 
 %end
 
-%post --nochroot
-# cp $INSTALL_ROOT/usr/share/licenses/*-release/* $LIVE_ROOT/
-
-# only works on x86_64
-# if [ "$(uname -m)" = "x86_64" ]; then
-#   if [ ! -d $LIVE_ROOT/LiveOS ]; then mkdir -p $LIVE_ROOT/LiveOS ; fi
-#   cp /usr/bin/livecd-iso-to-disk $LIVE_ROOT/LiveOS
-# fi
-
-%end
-
 %packages
 # Explicitly specified mandatory packages
 kernel
@@ -157,8 +135,7 @@ kernel-modules-extra
 # The point of a live image is to install
 anaconda
 anaconda-install-env-deps
-# TODO: "Install to Hard Drive" temporary disabled because of https://github.com/rhinstaller/anaconda/discussions/5997
-#anaconda-live
+anaconda-live
 @anaconda-tools
 # Anaconda has a weak dep on this and we don't want it on livecds, see
 # https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD

--- a/kickstarts/10/x86_64/almalinux-live-mate.ks
+++ b/kickstarts/10/x86_64/almalinux-live-mate.ks
@@ -19,7 +19,7 @@ url --url=https://repo.almalinux.org/almalinux/10/BaseOS/$basearch/os/
 repo --name="appstream" --baseurl=https://repo.almalinux.org/almalinux/10/AppStream/$basearch/os/
 repo --name="extras" --baseurl=https://repo.almalinux.org/almalinux/10/extras-common/$basearch/os/
 repo --name="crb" --baseurl=https://repo.almalinux.org/almalinux/10/CRB/$basearch/os/
-repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
+repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10z/Everything/$basearch/
 
 # Firewall configuration
 firewall --enabled --service=mdns

--- a/kickstarts/10/x86_64/almalinux-live-xfce.ks
+++ b/kickstarts/10/x86_64/almalinux-live-xfce.ks
@@ -19,7 +19,7 @@ url --url=https://repo.almalinux.org/almalinux/10/BaseOS/$basearch/os/
 repo --name="appstream" --baseurl=https://repo.almalinux.org/almalinux/10/AppStream/$basearch/os/
 repo --name="extras" --baseurl=https://repo.almalinux.org/almalinux/10/extras-common/$basearch/os/
 repo --name="crb" --baseurl=https://repo.almalinux.org/almalinux/10/CRB/$basearch/os/
-repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
+repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10z/Everything/$basearch/
 
 # Firewall configuration
 firewall --enabled --service=mdns
@@ -124,17 +124,6 @@ getent group openvpn &>/dev/null || groupadd -r openvpn
 getent passwd openvpn &>/dev/null || \
     /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
         -d /etc/openvpn openvpn
-
-%end
-
-%post --nochroot
-# cp $INSTALL_ROOT/usr/share/licenses/*-release/* $LIVE_ROOT/
-
-# only works on x86_64
-# if [ "$(uname -m)" = "x86_64" ]; then
-#   if [ ! -d $LIVE_ROOT/LiveOS ]; then mkdir -p $LIVE_ROOT/LiveOS ; fi
-#   cp /usr/bin/livecd-iso-to-disk $LIVE_ROOT/LiveOS
-# fi
 
 %end
 

--- a/kickstarts/10/x86_64_v2/almalinux-live-gnome-mini.ks
+++ b/kickstarts/10/x86_64_v2/almalinux-live-gnome-mini.ks
@@ -13,15 +13,11 @@ lang en_US.UTF-8
 firewall --enabled --service=mdns
 
 # Repos
-# url --url=https://repo.almalinux.org/almalinux/10/BaseOS/x86_64_v2/os/
-url --url=https://vault.almalinux.org/10.0-beta/BaseOS/x86_64_v2/os/
-# repo --name="appstream" --baseurl=https://repo.almalinux.org/almalinux/10/AppStream/x86_64_v2/os/
-repo --name="appstream" --baseurl=https://vault.almalinux.org/10.0-beta/AppStream/x86_64_v2/os/
-# repo --name="extras" --baseurl=https://repo.almalinux.org/almalinux/10/extras/x86_64_v2/os/
-repo --name="extras" --baseurl=https://vault.almalinux.org/10.0-beta/extras/x86_64_v2/os/
-# repo --name="crb" --baseurl=https://repo.almalinux.org/almalinux/10/CRB/x86_64_v2/os/
-repo --name="crb" --baseurl=https://vault.almalinux.org/10.0-beta/CRB/x86_64_v2/os/
-repo --name="livesys-scripts" --baseurl=https://build.almalinux.org/pulp/content/builds/AlmaLinux-Kitten-10-x86_64_v2-20702-br/
+url --url=https://repo.almalinux.org/almalinux/10/BaseOS/x86_64_v2/os/
+repo --name="appstream" --baseurl=https://repo.almalinux.org/almalinux/10/AppStream/x86_64_v2/os/
+repo --name="extras" --baseurl=https://repo.almalinux.org/almalinux/10/extras/x86_64_v2/os/
+repo --name="crb" --baseurl=https://repo.almalinux.org/almalinux/10/CRB/x86_64_v2/os/
+repo --name="epel" --baseurl=https://repo.almalinux.org/almalinux-epel/10z/x86_64_v2/
 
 # Network information
 network --activate --bootproto=dhcp --device=link --onboot=on
@@ -103,6 +99,9 @@ getent passwd openvpn &>/dev/null || \
     /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
         -d /etc/openvpn openvpn
 
+# TODO: To place Firefox into Task Manager
+# This should be removed when upstream fixes the livesys-scripts package
+sed -i  's/org.mozilla.firefox.desktop/firefox.desktop/g' /usr/libexec/livesys/sessions.d/livesys-gnome
 %end
 
 # Packages
@@ -115,7 +114,6 @@ kernel-modules-extra
 # The point of a live image is to install
 anaconda
 anaconda-install-env-deps
-# TODO: "Install to Hard Drive" temporary disabled because of https://github.com/rhinstaller/anaconda/discussions/5997
 anaconda-live
 @anaconda-tools
 # Anaconda has a weak dep on this and we don't want it on livecds, see
@@ -151,10 +149,13 @@ firefox
 # GNOME specific
 @gnome-desktop
 
+# EPEL repo
+epel-release
+
 # OpenVPN
-# openvpn
-# NetworkManager-openvpn
-# NetworkManager-openvpn-gnome
+openvpn
+NetworkManager-openvpn
+NetworkManager-openvpn-gnome
 
 # Exclude unwanted packages from @anaconda-tools group
 -gfs2-utils

--- a/kickstarts/10/x86_64_v2/almalinux-live-gnome.ks
+++ b/kickstarts/10/x86_64_v2/almalinux-live-gnome.ks
@@ -13,15 +13,11 @@ lang en_US.UTF-8
 firewall --enabled --service=mdns
 
 # Repos
-# url --url=https://repo.almalinux.org/almalinux/10/BaseOS/x86_64_v2/os/
-url --url=https://vault.almalinux.org/10.0-beta/BaseOS/x86_64_v2/os/
-# repo --name="appstream" --baseurl=https://repo.almalinux.org/almalinux/10/AppStream/x86_64_v2/os/
-repo --name="appstream" --baseurl=https://vault.almalinux.org/10.0-beta/AppStream/x86_64_v2/os/
-# repo --name="extras" --baseurl=https://repo.almalinux.org/almalinux/10/extras/x86_64_v2/os/
-repo --name="extras" --baseurl=https://vault.almalinux.org/10.0-beta/extras/x86_64_v2/os/
-# repo --name="crb" --baseurl=https://repo.almalinux.org/almalinux/10/CRB/x86_64_v2/os/
-repo --name="crb" --baseurl=https://vault.almalinux.org/10.0-beta/CRB/x86_64_v2/os/
-repo --name="livesys-scripts" --baseurl=https://build.almalinux.org/pulp/content/builds/AlmaLinux-Kitten-10-x86_64_v2-20702-br/
+url --url=https://repo.almalinux.org/almalinux/10/BaseOS/x86_64_v2/os/
+repo --name="appstream" --baseurl=https://repo.almalinux.org/almalinux/10/AppStream/x86_64_v2/os/
+repo --name="extras" --baseurl=https://repo.almalinux.org/almalinux/10/extras/x86_64_v2/os/
+repo --name="crb" --baseurl=https://repo.almalinux.org/almalinux/10/CRB/x86_64_v2/os/
+repo --name="epel" --baseurl=https://repo.almalinux.org/almalinux-epel/10z/x86_64_v2/
 
 # Network information
 network --activate --bootproto=dhcp --device=link --onboot=on
@@ -103,6 +99,9 @@ getent passwd openvpn &>/dev/null || \
     /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
         -d /etc/openvpn openvpn
 
+# TODO: To place Firefox into Task Manager
+# This should be removed when upstream fixes the livesys-scripts package
+sed -i  's/org.mozilla.firefox.desktop/firefox.desktop/g' /usr/libexec/livesys/sessions.d/livesys-gnome
 %end
 
 # Packages
@@ -115,8 +114,7 @@ kernel-modules-extra
 # The point of a live image is to install
 anaconda
 anaconda-install-env-deps
-# TODO: "Install to Hard Drive" temporary disabled because of https://github.com/rhinstaller/anaconda/discussions/5997
-#anaconda-live
+anaconda-live
 @anaconda-tools
 # Anaconda has a weak dep on this and we don't want it on livecds, see
 # https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD
@@ -148,7 +146,8 @@ firefox
 @^workstation-product-environment
 
 # GNOME specific
-@gnome-apps
+@gnome-desktop
+#@gnome-apps
 
 # Exclude unwanted packages from @anaconda-tools group
 -gfs2-utils
@@ -170,10 +169,13 @@ toolbox
 uresourced
 whois
 
+# EPEL repo
+epel-release
+
 # OpenVPN
-# openvpn
-# NetworkManager-openvpn
-# NetworkManager-openvpn-gnome
+openvpn
+NetworkManager-openvpn
+NetworkManager-openvpn-gnome
 
 # minimization
 -hplip

--- a/kickstarts/10/x86_64_v2/almalinux-live-kde.ks
+++ b/kickstarts/10/x86_64_v2/almalinux-live-kde.ks
@@ -1,47 +1,50 @@
-# AlmaLinux Live Media (Beta - experimental), with optional install option.
-# Build: sudo livecd-creator --cache=~/livecd-creator/package-cache -c almalinux-8-live-gnome.ks -f AlmaLinux-8-Live-gnome
+#version=DEVEL
 # X Window System configuration information
 xconfig  --startxonboot
 # Keyboard layouts
 keyboard 'us'
-
-# System timezone
-timezone US/Eastern
+# Root password
+rootpw --plaintext rootme
 # System language
 lang en_US.UTF-8
-# Firewall configuration
-firewall --enabled --service=mdns
+# Shutdown after installation
+shutdown
+# System timezone
+timezone US/Eastern
+# Network information
+network  --bootproto=dhcp --device=link --activate
 
 # Repos
-url --url=https://repo.almalinux.org/almalinux/10/BaseOS/$basearch/os/
-repo --name="appstream" --baseurl=https://repo.almalinux.org/almalinux/10/AppStream/$basearch/os/
-repo --name="extras" --baseurl=https://repo.almalinux.org/almalinux/10/extras/$basearch/os/
-repo --name="crb" --baseurl=https://repo.almalinux.org/almalinux/10/CRB/$basearch/os/
-repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10z/Everything/$basearch/
+url --url=https://repo.almalinux.org/almalinux/10/BaseOS/x86_64_v2/os/
+repo --name="appstream" --baseurl=https://repo.almalinux.org/almalinux/10/AppStream/x86_64_v2/os/
+repo --name="extras" --baseurl=https://repo.almalinux.org/almalinux/10/extras/x86_64_v2/os/
+repo --name="crb" --baseurl=https://repo.almalinux.org/almalinux/10/CRB/x86_64_v2/os/
+repo --name="epel" --baseurl=https://repo.almalinux.org/almalinux-epel/10z/x86_64_v2/
 
-# Network information
-network --activate --bootproto=dhcp --device=link --onboot=on
-
+# Firewall configuration
+firewall --enabled --service=mdns
 # SELinux configuration
 selinux --enforcing
 
 # System services
 services --disabled="sshd" --enabled="NetworkManager,ModemManager"
-
-# livemedia-creator modifications.
-shutdown
 # System bootloader configuration
 bootloader --location=none
-# Clear blank disks or all existing partitions
+# Clear the Master Boot Record
+zerombr
+# Partition clearing information
 clearpart --all --initlabel
-rootpw rootme
 # Disk partitioning information
 part / --size=10238
 
 %post
+
 # Enable livesys services
 systemctl enable livesys.service
 systemctl enable livesys-late.service
+
+# Enable sddm since EPEL packages it disabled by default
+systemctl enable sddm.service
 
 # enable tmpfs for /tmp
 systemctl enable tmp.mount
@@ -68,18 +71,37 @@ rm -f /var/lib/rpm/__db*
 # make sure there aren't core files lying around
 rm -f /core*
 
+# remove random seed, the newly installed instance should make it's own
+rm -f /var/lib/systemd/random-seed
+
 # convince readahead not to collect
 # FIXME: for systemd
 
 echo 'File created by kickstart. See systemd-update-done.service(8).' \
     | tee /etc/.updated >/var/.updated
 
-# Remove random-seed
-rm /var/lib/systemd/random-seed
-
-# Remove the rescue kernel and image to save space
-# Installation will recreate these on the target
+# Drop the rescue kernel and initramfs, we don't need them on the live media itself.
+# See bug 1317709
 rm -f /boot/*-rescue*
+
+# Theme wallpapers
+rm -f /usr/share/wallpapers/Fedora
+ln -s Alma-default /usr/share/wallpapers/Fedora
+# Locked screen wallpapers
+mkdir -p /home/liveuser/.config && chown -R liveuser:liveuser /home/liveuser/.config
+cat <<'EOF'>/home/liveuser/.config/kscreenlockerrc
+[Greeter][Wallpaper][org.kde.image][General]
+Image=/usr/share/wallpapers/Alma-default/
+PreviewImage=/usr/share/wallpapers/Alma-default/
+EOF
+# Login screen theme
+cat <<'EOF'>/etc/sddm.conf.d/kde_settings.conf
+[Theme]
+Current=breeze
+EOF
+# Replace live installer icon for the application and welcome center
+sed -i "s/Icon=.*$/Icon=\/usr\/share\/icons\/hicolor\/scalable\/apps\/org.fedoraproject.AnacondaInstaller.svg/g" \
+  /usr/share/applications/liveinst.desktop
 
 # Disable network service here, as doing it in the services line
 # fails due to RHBZ #1369794
@@ -90,7 +112,10 @@ rm -f /etc/machine-id
 touch /etc/machine-id
 
 # set livesys session type
-sed -i 's/^livesys_session=.*/livesys_session="gnome"/' /etc/sysconfig/livesys
+sed -i 's/^livesys_session=.*/livesys_session="kde"/' /etc/sysconfig/livesys
+
+# enable CRB repo
+dnf config-manager --enable crb
 
 # Workaround to add openvpn user and group in case they didn't added during
 # openvpn package installation
@@ -99,12 +124,8 @@ getent passwd openvpn &>/dev/null || \
     /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
         -d /etc/openvpn openvpn
 
-# TODO: To place Firefox into Task Manager
-# This should be removed when upstream fixes the livesys-scripts package
-sed -i  's/org.mozilla.firefox.desktop/firefox.desktop/g' /usr/libexec/livesys/sessions.d/livesys-gnome
 %end
 
-# Packages
 %packages
 # Explicitly specified mandatory packages
 kernel
@@ -136,18 +157,31 @@ livesys-scripts
 # Mandatory to build media with livemedia-creator
 memtest86+
 
-# firefox
-#@internet-browser
+# libreoffice group
+#@office-suite
+
+# internet-browser group
 firefox
 
-# Workstation environment group
-@^workstation-product-environment
+# KDE specific
+@dial-up
+@standard
 
-# Workstation specific
--@workstation-product
+# install env-group to resolve RhBug:1891500
+@^kde-desktop-environment
+-kde-connect
+-kdeconnectd
+-kde-connect-libs
 
-# GNOME specific
-@gnome-desktop
+@kde-apps
+@kde-media
+
+# drop tracker stuff pulled in by gtk3 (pagureio:fedora-kde/SIG#124)
+-tracker-miners
+-tracker
+
+# Additional packages that are not default in kde-* groups, but useful
+fuse
 
 # EPEL repo
 epel-release
@@ -155,12 +189,17 @@ epel-release
 # OpenVPN
 openvpn
 NetworkManager-openvpn
-NetworkManager-openvpn-gnome
 
-# Exclude unwanted packages from @anaconda-tools group
--gfs2-utils
--reiserfs-utils
+### space issues
+-ktorrent			# kget has also basic torrent features (~3 megs)
+-digikam			# digikam has duplicate functionality with gwenview (~28 megs)
+-kipi-plugins			# ~8 megs + drags in Marble
+-krusader			# ~4 megs
+-k3b				# ~15 megs
 
 # minimization
 -hplip
+
+# Add alsa-sof-firmware to all images PR #51
+alsa-sof-firmware
 %end


### PR DESCRIPTION
- KDE:
    - Add x86_64_v2 kickstart.
- GNOME:
    - Refine GNOME images: disable @gnome-apps, install @gnome-desktop.
    - Add Firefox to GNOME Task Manager.
- General Image Improvements:
    - Revert install of anaconda-live package.
    - Install epel-release and OpenVPN packages for x86_64_v2.
    - Correct EPEL repository path to use '10z'.
    - Clean up kickstarts by removing unused '%post --nochroot' sections, remove setiing default GTK+ theme for root user

CI:
- Add build targets for KDE on x86_64 and aarch64.
- Exclude GNOME and GNOME Mini build targets for x86_64_v2.