### PR TITLE
AlmaLinux Kitten release 10 Live Images

### DIFF
--- a/.github/workflows/build-media.yml
+++ b/.github/workflows/build-media.yml
@@ -102,9 +102,6 @@ jobs:
           # TODO: the excludes below should be removed when '10-kitten' provides need packages
           - version: 10-kitten
             arch: x86_64_v2
-            image_type: KDE
-          - version: 10-kitten
-            arch: x86_64_v2
             image_type: MATE
           - version: 10-kitten
             arch: x86_64_v2

--- a/kickstarts/10-kitten/aarch64/almalinux-live-gnome-mini.ks
+++ b/kickstarts/10-kitten/aarch64/almalinux-live-gnome-mini.ks
@@ -99,6 +99,9 @@ getent passwd openvpn &>/dev/null || \
     /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
         -d /etc/openvpn openvpn
 
+# TODO: To place Firefox into Task Manager
+# This should be removed when upstream fixes the livesys-scripts package
+sed -i  's/org.mozilla.firefox.desktop/firefox.desktop/g' /usr/libexec/livesys/sessions.d/livesys-gnome
 %end
 
 # Packages

--- a/kickstarts/10-kitten/aarch64/almalinux-live-gnome.ks
+++ b/kickstarts/10-kitten/aarch64/almalinux-live-gnome.ks
@@ -99,6 +99,9 @@ getent passwd openvpn &>/dev/null || \
     /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
         -d /etc/openvpn openvpn
 
+# TODO: To place Firefox into Task Manager
+# This should be removed when upstream fixes the livesys-scripts package
+sed -i  's/org.mozilla.firefox.desktop/firefox.desktop/g' /usr/libexec/livesys/sessions.d/livesys-gnome
 %end
 
 # Packages
@@ -172,7 +175,7 @@ thunderbird
 bash-color-prompt
 exfatprogs
 fpaste
-#iptstate
+iptstate
 nss-mdns
 #ntfs-3g
 #ntfsprogs

--- a/kickstarts/10-kitten/x86_64/almalinux-live-gnome-mini.ks
+++ b/kickstarts/10-kitten/x86_64/almalinux-live-gnome-mini.ks
@@ -99,6 +99,9 @@ getent passwd openvpn &>/dev/null || \
     /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
         -d /etc/openvpn openvpn
 
+# TODO: To place Firefox into Task Manager
+# This should be removed when upstream fixes the livesys-scripts package
+sed -i  's/org.mozilla.firefox.desktop/firefox.desktop/g' /usr/libexec/livesys/sessions.d/livesys-gnome
 %end
 
 # Packages

--- a/kickstarts/10-kitten/x86_64/almalinux-live-gnome.ks
+++ b/kickstarts/10-kitten/x86_64/almalinux-live-gnome.ks
@@ -99,6 +99,9 @@ getent passwd openvpn &>/dev/null || \
     /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
         -d /etc/openvpn openvpn
 
+# TODO: To place Firefox into Task Manager
+# This should be removed when upstream fixes the livesys-scripts package
+sed -i  's/org.mozilla.firefox.desktop/firefox.desktop/g' /usr/libexec/livesys/sessions.d/livesys-gnome
 %end
 
 # Packages
@@ -154,7 +157,7 @@ firefox
 bash-color-prompt
 exfatprogs
 fpaste
-#iptstate
+iptstate
 nss-mdns
 #ntfs-3g
 #ntfsprogs

--- a/kickstarts/10-kitten/x86_64_v2/almalinux-live-gnome.ks
+++ b/kickstarts/10-kitten/x86_64_v2/almalinux-live-gnome.ks
@@ -17,6 +17,7 @@ url --url=https://kitten.repo.almalinux.org/10-kitten/BaseOS/x86_64_v2/os/
 repo --name="appstream" --baseurl=https://kitten.repo.almalinux.org/10-kitten/AppStream/x86_64_v2/os/
 repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extras-common/x86_64_v2/os/
 repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/x86_64_v2/os/
+repo --name="epel" --baseurl=https://epel.repo.almalinux.org/10/x86_64_v2/
 
 # Network information
 network --activate --bootproto=dhcp --device=link --onboot=on
@@ -98,6 +99,9 @@ getent passwd openvpn &>/dev/null || \
     /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
         -d /etc/openvpn openvpn
 
+# TODO: To place Firefox into Task Manager
+# This should be removed when upstream fixes the livesys-scripts package
+sed -i  's/org.mozilla.firefox.desktop/firefox.desktop/g' /usr/libexec/livesys/sessions.d/livesys-gnome
 %end
 
 # Packages
@@ -129,7 +133,7 @@ glibc-all-langpacks
 # provide the livesys scripts
 livesys-scripts
 
-# Memtest boot option
+# Mandatory to build media with livemedia-creator
 memtest86+
 
 # libreoffice group
@@ -152,9 +156,9 @@ firefox
 # Workstation specific
 bash-color-prompt
 exfatprogs
-#fpaste
-#iptstate
-#nss-mdns
+fpaste
+iptstate
+nss-mdns
 #ntfs-3g
 #ntfsprogs
 policycoreutils-python-utils
@@ -165,10 +169,13 @@ toolbox
 uresourced
 whois
 
+# EPEL repo
+epel-release
+
 # OpenVPN
-# openvpn
-# NetworkManager-openvpn
-# NetworkManager-openvpn-gnome
+openvpn
+NetworkManager-openvpn
+NetworkManager-openvpn-gnome
 
 # minimization
 -hplip

--- a/kickstarts/10/aarch64/almalinux-live-gnome.ks
+++ b/kickstarts/10/aarch64/almalinux-live-gnome.ks
@@ -175,7 +175,7 @@ thunderbird
 bash-color-prompt
 exfatprogs
 fpaste
-#iptstate
+iptstate
 nss-mdns
 #ntfs-3g
 #ntfsprogs

--- a/kickstarts/10/x86_64/almalinux-live-gnome.ks
+++ b/kickstarts/10/x86_64/almalinux-live-gnome.ks
@@ -157,7 +157,7 @@ firefox
 bash-color-prompt
 exfatprogs
 fpaste
-#iptstate
+iptstate
 nss-mdns
 #ntfs-3g
 #ntfsprogs

--- a/kickstarts/10/x86_64_v2/almalinux-live-gnome.ks
+++ b/kickstarts/10/x86_64_v2/almalinux-live-gnome.ks
@@ -157,7 +157,7 @@ firefox
 bash-color-prompt
 exfatprogs
 #fpaste
-#iptstate
+iptstate
 #nss-mdns
 #ntfs-3g
 #ntfsprogs


### PR DESCRIPTION
- KDE:
    - Add x86_64_v2 kickstart.
    - Change "Install to Hard Drive" application icon on welcome, menu and desktop
- GNOME:
    - Add Firefox to GNOME Task Manager.
    - Install iptstate package
- General Image Improvements:
    - Install epel-release and OpenVPN packages for x86_64_v2.
    - Correct EPEL repository path for x86_64_v2.
    - Clean up kickstarts by removing unused '%post --nochroot' sections, remove setiing default GTK+ theme for root user

CI:
- Add build target for KDE on x86_64_v2.

AlmaLinux release 10.0 GNOME Live Images:
- Install iptstate package