### PR TITLE
AlmaLinux release 10.0 Live Images for x86_64_v2

### DIFF
--- a/.github/workflows/build-media.yml
+++ b/.github/workflows/build-media.yml
@@ -99,6 +99,10 @@ jobs:
             arch: x86_64_v2
           - version: 9
             arch: x86_64_v2
+          - image_type: GNOME-Mini
+            version: 10
+          - image_type: GNOME-Mini
+            version: 10-kitten
           # TODO: the excludes below should be removed when '10-kitten' provides need packages
           - version: 10-kitten
             arch: x86_64_v2
@@ -107,15 +111,6 @@ jobs:
             arch: x86_64_v2
             image_type: XFCE
           # TODO: the excludes below should be removed when '10' provides need packages
-          - version: 10
-            arch: x86_64_v2
-            image_type: GNOME
-          - version: 10
-            arch: x86_64_v2
-            image_type: GNOME-Mini
-          - version: 10
-            arch: x86_64_v2
-            image_type: KDE
           - version: 10
             arch: x86_64_v2
             image_type: MATE

--- a/kickstarts/10/aarch64/almalinux-live-gnome.ks
+++ b/kickstarts/10/aarch64/almalinux-live-gnome.ks
@@ -175,7 +175,7 @@ thunderbird
 bash-color-prompt
 exfatprogs
 fpaste
-iptstate
+# iptstate
 nss-mdns
 #ntfs-3g
 #ntfsprogs

--- a/kickstarts/10/x86_64/almalinux-live-gnome.ks
+++ b/kickstarts/10/x86_64/almalinux-live-gnome.ks
@@ -157,7 +157,7 @@ firefox
 bash-color-prompt
 exfatprogs
 fpaste
-iptstate
+# iptstate
 nss-mdns
 #ntfs-3g
 #ntfsprogs

--- a/kickstarts/10/x86_64_v2/almalinux-live-gnome.ks
+++ b/kickstarts/10/x86_64_v2/almalinux-live-gnome.ks
@@ -157,7 +157,7 @@ firefox
 bash-color-prompt
 exfatprogs
 #fpaste
-iptstate
+# iptstate
 #nss-mdns
 #ntfs-3g
 #ntfsprogs


### PR DESCRIPTION
GNOME:
- Do not install iptstate package

CI:
- enable GNOME, GNOME Mini and KDE images building for x86_64_v2
- exclude GNOME Mini building for 10 and 10-kitten. Lack of libreoffice packages makes GNOME and Mini images almost the same size.