### PR TITLE
Do not modify /usr/share/wallpapers/Fedora symlink in AlmaLinux 10 KDE

### DIFF
--- a/kickstarts/10/aarch64/almalinux-live-kde.ks
+++ b/kickstarts/10/aarch64/almalinux-live-kde.ks
@@ -84,10 +84,6 @@ echo 'File created by kickstart. See systemd-update-done.service(8).' \
 # See bug 1317709
 rm -f /boot/*-rescue*
 
-# Theme wallpapers
-rm -f /usr/share/wallpapers/Fedora
-ln -s Alma-default /usr/share/wallpapers/Fedora
-
 # Login screen theme and wallpapers
 cat <<'EOF'>/etc/sddm.conf.d/kde_settings.conf
 [Theme]

--- a/kickstarts/10/x86_64/almalinux-live-kde.ks
+++ b/kickstarts/10/x86_64/almalinux-live-kde.ks
@@ -84,10 +84,6 @@ echo 'File created by kickstart. See systemd-update-done.service(8).' \
 # See bug 1317709
 rm -f /boot/*-rescue*
 
-# Theme wallpapers
-rm -f /usr/share/wallpapers/Fedora
-ln -s Alma-default /usr/share/wallpapers/Fedora
-
 # Login screen theme and wallpapers
 cat <<'EOF'>/etc/sddm.conf.d/kde_settings.conf
 [Theme]

--- a/kickstarts/10/x86_64_v2/almalinux-live-kde.ks
+++ b/kickstarts/10/x86_64_v2/almalinux-live-kde.ks
@@ -84,10 +84,6 @@ echo 'File created by kickstart. See systemd-update-done.service(8).' \
 # See bug 1317709
 rm -f /boot/*-rescue*
 
-# Theme wallpapers
-rm -f /usr/share/wallpapers/Fedora
-ln -s Alma-default /usr/share/wallpapers/Fedora
-
 # Login screen theme and wallpapers
 cat <<'EOF'>/etc/sddm.conf.d/kde_settings.conf
 [Theme]


### PR DESCRIPTION
`/usr/share/wallpapers/Fedora` symlink is provided by `kde-settings-plasma` package and by default points to `/usr/share/wallpapers/Default`.
We provide `Default` symlink in `almalinux-logos` since 10.2 so no need to modify `Fedora` symlink anymore.