### PR TITLE
Add NVIDIA drivers to live images for 9, 10 and 10-Kitten

### DIFF
--- a/.github/actions/shared-steps/action.yml
+++ b/.github/actions/shared-steps/action.yml
@@ -41,6 +41,10 @@ inputs:
   notify_mattermost:
     description: "Whether to send notification to Mattermost"
     required: true
+  with_nvidia:
+    description: "Whether to include NVIDIA GPU drivers"
+    required: true
+    default: "false"
 
 runs:
   using: "composite"
@@ -79,6 +83,15 @@ runs:
             echo "Almalinux ${{ inputs.version_major }} is not supported!" && false
             ;;
         esac
+
+        if [ "${{ inputs.with_nvidia }}" = "true" ]; then
+          results_name="${results_name}-NVIDIA"
+          iso_dir="iso_${{ inputs.version_major }}_${{ inputs.arch }}_${{ inputs.image_type }}-NVIDIA"
+        else
+          iso_dir="iso_${{ inputs.image_type }}"
+        fi
+
+        echo "iso_dir=${iso_dir}" >> $GITHUB_ENV
 
         # AlmaLinux "code" name
         echo "code_name_var=${code_name_var}" >> $GITHUB_ENV
@@ -134,7 +147,11 @@ runs:
         build_env="RESULT_DIR=${{ env.RESULT_DIR }}"
         [ "${{ inputs.arch }}" = "x86_64_v2" ] && build_env="${build_env} BUILD_X86_64_V2=1"
         [ "${{ inputs.version_major }}" = "10-kitten" ] && build_env="${build_env} DATE_STAMP=${{ env.date_stamp }} ITERATION=${{ inputs.iteration }}"
-        ${{ env.run }} "cd ${{ env.build_work_dir }} && sudo ${build_env} bash /vagrant/build-livemedia.sh ${{ inputs.version_major }} ${{ inputs.image_type }}"
+        
+        nvidia_flag=""
+        [ "${{ inputs.with_nvidia }}" = "true" ] && nvidia_flag="--with-nvidia"
+        
+        ${{ env.run }} "cd ${{ env.build_work_dir }} && sudo ${build_env} bash /vagrant/build-livemedia.sh ${{ inputs.version_major }} ${{ inputs.image_type }} ${nvidia_flag}"
 
     - name: Get ISO media
       if: inputs.store_as_artifact == 'true' || inputs.upload_to_s3 == 'true'
@@ -142,7 +159,7 @@ runs:
       shell: bash
       run: |
         # Get media into the host
-        source="${{ env.RESULT_DIR }}/iso_${{ inputs.image_type }}/${{ env.results_name }}.iso"
+        source="${{ env.RESULT_DIR }}/${{ env.iso_dir }}/${{ env.results_name }}.iso"
         target="${{ env.results_path }}/"
         ${{ env.copy_from }}
 

--- a/.github/workflows/build-media.yml
+++ b/.github/workflows/build-media.yml
@@ -92,6 +92,7 @@ jobs:
     name: ${{ matrix.version }} ${{ matrix.arch }} ${{ matrix.image_type }}
     needs: [init-data]
     runs-on: ubuntu-24.04
+    if: ${{ !(inputs.with_nvidia && matrix.arch == 'x86_64_v2') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-media.yml
+++ b/.github/workflows/build-media.yml
@@ -68,6 +68,12 @@ on:
         type: boolean
         default: false
 
+      with_nvidia:
+        description: 'Include NVIDIA GPU drivers (AlmaLinux 9/10/10-kitten only)'
+        required: true
+        type: boolean
+        default: false
+
 jobs:
   init-data:
     name: Initialize common data
@@ -227,6 +233,7 @@ jobs:
           store_as_artifact: ${{ inputs.store_as_artifact }}
           upload_to_s3: ${{ inputs.upload_to_s3 }}
           notify_mattermost: ${{ inputs.notify_mattermost }}
+          with_nvidia: ${{ inputs.with_nvidia }}
 
 
   start-aarch64-runner:
@@ -371,3 +378,4 @@ jobs:
           store_as_artifact: ${{ inputs.store_as_artifact }}
           upload_to_s3: ${{ inputs.upload_to_s3 }}
           notify_mattermost: ${{ inputs.notify_mattermost }}
+          with_nvidia: ${{ inputs.with_nvidia }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ flat-*.ks
 kickstarts/commands_to_build
 packages/
 .vagrant
+results/

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ sudo ./build-livemedia.sh 10-kitten GNOME-Mini
 # To build media with x86_64_v2 packages for AlmaLinux 10+ (optional)
 BUILD_X86_64_V2=1 sudo ./build-livemedia.sh 10 KDE
 
+# Build AlmaLinux 10.2 GNOME Live Media with NVIDIA GPU drivers
+sudo ./build-livemedia.sh 10 GNOME --with-nvidia
+
 # Show all available options
 ./build-livemedia.sh --help
 ```
@@ -465,6 +468,18 @@ The following desktop environments are supported:
 | 10-kitten | x86_64    | ✅    | ✅         | ✅  | ✅   | ✅   |
 | 10-kitten | aarch64   | ✅    | ✅         | ✅  | ✅   | ✅   |
 | 10-kitten | x86_64_v2 | ✅    | ✅         | ✅  | ❌   | ❌   |
+
+#### NVIDIA GPU Driver Support
+
+You can build Live Media ISOs with the official NVIDIA GPU driver stack pre-installed by passing the `--with-nvidia` flag:
+* **Supported OS Versions**: AlmaLinux 9, 10, and 10-kitten.
+* **Supported Architectures**: `x86_64` (standard v1) and `aarch64`.
+* **Unsupported configurations**: NVIDIA support is **not** available for AlmaLinux 8 or `x86_64_v2` architectures.
+* **Local Build Dependency Warning (DNF5 Host)**: Because DNF5 on AlmaLinux 10 host machines does not download `filelists` metadata by default, building an AlmaLinux 9 image on an AlmaLinux 10 host will fail to resolve some file paths. Enable filelists on the host first by running:
+  ```sh
+  echo "optional_metadata_types = filelists" | sudo tee -a /etc/dnf/dnf.conf
+  sudo dnf makecache
+  ```
 
 #### Troubleshooting
 * For AlmaLinux 10, SELinux may need to be set to permissive: `sudo setenforce 0`

--- a/README.md
+++ b/README.md
@@ -7,28 +7,31 @@ This git repository contains Kickstarts and other scripts needed to produce the 
 Live media ISO files are available for download from the official AlmaLinux repositories:
 
 **AlmaLinux 8:**
-- x86_64: https://repo.almalinux.org/almalinux/8/live/x86_64/
+
+- x86_64: <https://repo.almalinux.org/almalinux/8/live/x86_64/>
 
 **AlmaLinux 9:**
-- x86_64: https://repo.almalinux.org/almalinux/9/live/x86_64/
-- aarch64: https://repo.almalinux.org/almalinux/9/live/aarch64/
+
+- x86_64: <https://repo.almalinux.org/almalinux/9/live/x86_64/>
+- aarch64: <https://repo.almalinux.org/almalinux/9/live/aarch64/>
 
 **AlmaLinux 10:**
-- x86_64: https://repo.almalinux.org/almalinux/10/live/x86_64/
-- x86_64_v2: https://repo.almalinux.org/almalinux/10/live/x86_64_v2/
-- aarch64: https://repo.almalinux.org/almalinux/10/live/aarch64/
+
+- x86_64: <https://repo.almalinux.org/almalinux/10/live/x86_64/>
+- x86_64_v2: <https://repo.almalinux.org/almalinux/10/live/x86_64_v2/>
+- aarch64: <https://repo.almalinux.org/almalinux/10/live/aarch64/>
 
 **AlmaLinux Kitten (Development):**
-- x86_64: https://kitten.repo.almalinux.org/10-kitten/live/x86_64/
-- x86_64_v2: https://kitten.repo.almalinux.org/10-kitten/live/x86_64_v2/
-- aarch64: https://kitten.repo.almalinux.org/10-kitten/live/aarch64/
 
-For faster downloads, use mirrors at https://mirrors.almalinux.org to find a location closer to you. Refer to the project wiki https://wiki.almalinux.org/LiveMedia.html#about-live-media for detailed installation and usage instructions.
+- x86_64: <https://kitten.repo.almalinux.org/10-kitten/live/x86_64/>
+- x86_64_v2: <https://kitten.repo.almalinux.org/10-kitten/live/x86_64_v2/>
+- aarch64: <https://kitten.repo.almalinux.org/10-kitten/live/aarch64/>
+
+For faster downloads, use mirrors at <https://mirrors.almalinux.org> to find a location closer to you. Refer to the project wiki <https://wiki.almalinux.org/LiveMedia.html#about-live-media> for detailed installation and usage instructions.
 
 ## Build Live Media
 
 Building AlmaLinux Live media requires an AlmaLinux system (physical or virtual). The build process takes `20-50 minutes` depending on CPU cores and internet speed. You need minimum `15GB` workspace for temporary files. Resulting ISO size ranges from `1.4GB` to `2.4GB` depending on desktop environment.
-
 
 ### Build Environments
 
@@ -43,24 +46,28 @@ This project contains number of `KickStart` files to build live media for AlmaLi
 #### Install Required Packages
 
 **For AlmaLinux 8:**
+
 ```sh
 sudo dnf update -y
 sudo dnf install -y --enablerepo=powertools lorax lorax-templates-almalinux anaconda unzip zstd
 ```
 
 **For AlmaLinux 9:**
+
 ```sh
 sudo dnf update -y
 sudo dnf install -y --enablerepo=crb lorax lorax-templates-almalinux anaconda unzip zstd libblockdev-nvme
 ```
 
 **For AlmaLinux 10:**
+
 ```sh
 sudo dnf update -y
 sudo dnf install -y --enablerepo=crb lorax lorax-templates-almalinux anaconda unzip zstd libblockdev-nvme
 ```
 
 **Note:** For AlmaLinux 10, you may need to temporarily set SELinux to permissive mode:
+
 ```sh
 sudo setenforce 0
 ```
@@ -93,6 +100,7 @@ sudo ./build-livemedia.sh 10 GNOME --with-nvidia
 ```
 
 **Features:**
+
 - **Automated setup**: Installs required packages and prepares build environment
 - **Smart versioning**: Automatically maps major versions to current releases (8→8.10, 9→9.8, 10→10.2)
 - **Architecture detection**: Supports x86_64, aarch64, and x86_64_v2 automatically
@@ -101,6 +109,7 @@ sudo ./build-livemedia.sh 10 GNOME --with-nvidia
 - **Checksum generation**: Automatically creates SHA256 checksums for built ISOs
 
 **Supported combinations:**
+
 - **Versions**: 8, 9, 10, 10-kitten
 - **Desktop Environments**: GNOME, GNOME-Mini, KDE, XFCE, MATE
 - **Architecture**: Version-specific support (see table below)
@@ -116,6 +125,7 @@ For advanced users or custom builds, you can use `livemedia-creator` directly. T
 #### AlmaLinux 8.10 Examples
 
 **GNOME Live Media:**
+
 ```sh
 sudo livemedia-creator \
     --ks=./kickstarts/8/x86_64/almalinux-live-gnome.ks \
@@ -133,6 +143,7 @@ sudo livemedia-creator \
 ```
 
 **GNOME-Mini Live Media:**
+
 ```sh
 sudo livemedia-creator \
     --ks=./kickstarts/8/x86_64/almalinux-live-gnome-mini.ks \
@@ -150,6 +161,7 @@ sudo livemedia-creator \
 ```
 
 **KDE Live Media:**
+
 ```sh
 sudo livemedia-creator \
     --ks=./kickstarts/8/x86_64/almalinux-live-kde.ks \
@@ -169,6 +181,7 @@ sudo livemedia-creator \
 #### AlmaLinux 9.8 Examples
 
 **GNOME Live Media:**
+
 ```sh
 sudo livemedia-creator \
     --ks=./kickstarts/9/x86_64/almalinux-live-gnome.ks \
@@ -185,6 +198,7 @@ sudo livemedia-creator \
 ```
 
 **MATE Live Media:**
+
 ```sh
 sudo livemedia-creator \
     --ks=./kickstarts/9/x86_64/almalinux-live-mate.ks \
@@ -203,6 +217,7 @@ sudo livemedia-creator \
 #### AlmaLinux 10.2 Examples
 
 **GNOME Live Media:**
+
 ```sh
 sudo livemedia-creator \
     --ks=./kickstarts/10/x86_64/almalinux-live-gnome.ks \
@@ -219,6 +234,7 @@ sudo livemedia-creator \
 ```
 
 **KDE Live Media:**
+
 ```sh
 sudo livemedia-creator \
     --ks=./kickstarts/10/x86_64/almalinux-live-kde.ks \
@@ -239,6 +255,7 @@ sudo livemedia-creator \
 For different architectures, adjust the kickstart path and output names accordingly:
 
 **For aarch64 (ARM64):**
+
 ```sh
 sudo livemedia-creator \
     --ks=./kickstarts/9/aarch64/almalinux-live-gnome.ks \
@@ -280,11 +297,13 @@ AlmaLinux Live Media can be customized by editing the corresponding kickstart (`
 ### Kickstart File Structure
 
 Kickstart files are organized as:
+
 ```
 kickstarts/{version}/{architecture}/almalinux-live-{desktop}.ks
 ```
 
 **Examples:**
+
 - `kickstarts/9/x86_64/almalinux-live-gnome.ks` - AlmaLinux 9 GNOME for x86_64
 - `kickstarts/10/aarch64/almalinux-live-kde.ks` - AlmaLinux 10 KDE for aarch64
 - `kickstarts/8/x86_64/almalinux-live-mate.ks` - AlmaLinux 8 MATE for x86_64
@@ -336,6 +355,7 @@ repo --name="local-repo" --baseurl=file:///path/to/local/repo
 #### 3. System Configuration
 
 **Keyboard and Language:**
+
 ```bash
 # Keyboard layout
 keyboard us
@@ -348,12 +368,14 @@ timezone America/New_York --isUtc
 ```
 
 **Network Configuration:**
+
 ```bash
 # Enable NetworkManager
 network --onboot=yes --device=link --bootproto=dhcp --hostname=almalinux-live
 ```
 
 **Services Management:**
+
 ```bash
 # Enable services
 services --enabled=NetworkManager,sshd,chronyd
@@ -421,9 +443,11 @@ fi
 
 1. **Edit the appropriate kickstart file** for your target version/architecture/desktop
 2. **Build with your modifications** using the build script:
+
    ```bash
    sudo ./build-livemedia.sh 9 GNOME
    ```
+
 3. **Test the resulting ISO** in a virtual machine before deployment
 4. **Check logs** in `./results/logs/` if the build fails
 
@@ -434,6 +458,7 @@ fi
 - **Use package groups** (@core, @base, etc.) when possible for easier maintenance
 - **Document your changes** in comments within the kickstart file
 - **Validate syntax** using `ksvalidator` if available:
+
   ```bash
   ksvalidator kickstarts/9/x86_64/almalinux-live-gnome.ks
   ```
@@ -441,14 +466,18 @@ fi
 ### Additional Notes
 
 #### Build Tips
-* **Recommended approach:** Use the `build-livemedia.sh` script for automated, error-free builds
-* **Performance:** The build process benefits from multiple CPU cores and faster storage (SSD recommended)
-* **Network:** Builds require downloading packages; a stable internet connection is essential
-* **Storage:** Ensure at least 15GB free space for temporary files and output ISOs
-* **Logs:** The build script automatically creates comprehensive logs; manual builds should use `--logfile` parameter
+
+- **Recommended approach:** Use the `build-livemedia.sh` script for automated, error-free builds
+
+- **Performance:** The build process benefits from multiple CPU cores and faster storage (SSD recommended)
+- **Network:** Builds require downloading packages; a stable internet connection is essential
+- **Storage:** Ensure at least 15GB free space for temporary files and output ISOs
+- **Logs:** The build script automatically creates comprehensive logs; manual builds should use `--logfile` parameter
 
 #### Available Desktop Environments
+
 The following desktop environments are supported:
+
 - **GNOME** - Full-featured desktop environment
 - **GNOME-Mini** - Minimal GNOME variant
 - **KDE** - Modern Plasma desktop
@@ -472,22 +501,28 @@ The following desktop environments are supported:
 #### NVIDIA GPU Driver Support
 
 You can build Live Media ISOs with the official NVIDIA GPU driver stack pre-installed by passing the `--with-nvidia` flag:
-* **Supported OS Versions**: AlmaLinux 9, 10, and 10-kitten.
-* **Supported Architectures**: `x86_64` (standard v1) and `aarch64`.
-* **Unsupported configurations**: NVIDIA support is **not** available for AlmaLinux 8 or `x86_64_v2` architectures.
-* **Local Build Dependency Warning (DNF5 Host)**: Because DNF5 on AlmaLinux 10 host machines does not download `filelists` metadata by default, building an AlmaLinux 9 image on an AlmaLinux 10 host will fail to resolve some file paths. Enable filelists on the host first by running:
+
+- **Supported OS Versions**: AlmaLinux 9, 10, and 10-kitten.
+- **Supported Architectures**: `x86_64` and `aarch64`.
+- **Unsupported configurations**: NVIDIA support is **not** available for AlmaLinux 8 or `x86_64_v2` architectures.
+- **Local Build Dependency Warning (DNF5 Host)**: Because DNF5 on AlmaLinux 10 host machines does not download `filelists` metadata by default, building an AlmaLinux 9 image on an AlmaLinux 10 host will fail to resolve some file paths. Enable filelists on the host first by running:
+
   ```sh
   echo "optional_metadata_types = filelists" | sudo tee -a /etc/dnf/dnf.conf
   sudo dnf makecache
   ```
 
 #### Troubleshooting
-* For AlmaLinux 10, SELinux may need to be set to permissive: `sudo setenforce 0`
-* Volume IDs are limited to 32 characters due to ISO9660 specification
-* Repository mirrors: Use https://mirrors.almalinux.org to find optimal mirrors
+
+- For AlmaLinux 10, SELinux may need to be set to permissive: `sudo setenforce 0`
+
+- Volume IDs are limited to 32 characters due to ISO9660 specification
+- Repository mirrors: Use <https://mirrors.almalinux.org> to find optimal mirrors
 
 #### CI/CD Integration
+
 This repository includes GitHub Actions workflows that automatically build live media images. The workflows support:
+
 - Multiple AlmaLinux versions (8, 9, 10, 10-kitten)
 - Multiple architectures and desktop environments
 - GitHub Actions artifact publishing

--- a/build-livemedia.sh
+++ b/build-livemedia.sh
@@ -44,15 +44,17 @@ show_help() {
     cat << EOF
 AlmaLinux Live Media Builder
 
-Usage: $0 <version_major> <desktop_environment>
+Usage: $0 <version_major> <desktop_environment> [--with-nvidia]
 
 Arguments:
   version_major         AlmaLinux major version (8, 9, 10, 10-kitten)
   desktop_environment   Desktop environment (GNOME, GNOME-Mini, KDE, XFCE, MATE)
+  --with-nvidia         Optional: Include NVIDIA GPU drivers (AlmaLinux 9, 10, 10-kitten only)
 
 Examples:
   $0 9 GNOME              # Build AlmaLinux 9.8 GNOME Live Media
   $0 10 KDE               # Build AlmaLinux 10.2 KDE Live Media
+  $0 10 GNOME --with-nvidia # Build AlmaLinux 10.2 GNOME with NVIDIA drivers
   $0 10-kitten GNOME-Mini # Build AlmaLinux Kitten GNOME-Mini Live Media
   $0 8 MATE               # Build AlmaLinux 8.10 MATE Live Media
 
@@ -66,13 +68,14 @@ Supported desktop environments:
 Architecture support:
   - AlmaLinux 8: x86_64
   - AlmaLinux 9: x86_64, aarch64
-  - AlmaLinux 10/10-kitten: x86_64, aarch64, x86_64_v2
+  - AlmaLinux 10: x86_64, aarch64, x86_64_v2
+  - AlmaLinux 10-kitten: x86_64, aarch64, x86_64_v2
 
 Environment variables:
   RESULT_DIR          Override default results directory (default: \$(pwd)/results)
-  BUILD_X86_64_V2=1   Build for x86_64_v2 architecture (AlmaLinux 10/10-kitten only)
-  DATE_STAMP          Override date stamp for 10-kitten builds (default: current date)
-  ITERATION           Override build iteration for 10-kitten builds (default: 0)
+  BUILD_X86_64_V2=1   Build with x86_64_v2 packages (10/10-kitten only)
+  DATE_STAMP=YYYYMMDD   Override default date stamp for Kitten build
+  ITERATION=N           Override default build iteration for Kitten build (default: 0)
 
 Requirements:
   - AlmaLinux system (8, 9, or 10)
@@ -82,19 +85,36 @@ Requirements:
 EOF
 }
 
-# Validate arguments
-if [[ $# -ne 2 ]]; then
-    show_help
-    exit 1
-fi
-
 if [[ "$1" == "-h" ]] || [[ "$1" == "--help" ]]; then
     show_help
     exit 0
 fi
 
+# Validate arguments
+if [[ $# -ne 2 ]] && [[ $# -ne 3 ]]; then
+    show_help
+    exit 1
+fi
+
 VERSION_MAJOR="$1"
 DESKTOP_ENV="$2"
+WITH_NVIDIA=false
+
+# Check for optional --with-nvidia flag
+if [[ $# -eq 3 ]]; then
+    if [[ "$3" == "--with-nvidia" ]]; then
+        WITH_NVIDIA=true
+    else
+        error "Invalid option: $3. Only --with-nvidia is supported."
+    fi
+fi
+
+# NVIDIA is only available for AlmaLinux 9, 10 and 10-kitten
+if [[ "${WITH_NVIDIA}" == true ]]; then
+    if [[ ! "${VERSION_MAJOR}" =~ ^(9|10) ]]; then
+        error "NVIDIA drivers are only available for AlmaLinux 9, 10 and 10-kitten"
+    fi
+fi
 
 # Validate version
 case "${VERSION_MAJOR}" in
@@ -202,20 +222,43 @@ if [[ "${ARCH}" == "x86_64_v2" ]]; then
     esac
 fi
 
+# Validate NVIDIA support on requested architecture
+if [[ "${WITH_NVIDIA}" == true ]]; then
+    if [[ "${ARCH}" == "x86_64_v2" ]]; then
+        error "NVIDIA drivers are not supported on x86_64_v2 architecture"
+    fi
+fi
+
 # Set file names and paths
-KICKSTART_FILE="almalinux-live-$(echo "${DESKTOP_ENV}" | tr '[:upper:]' '[:lower:]').ks"
+if [[ "${WITH_NVIDIA}" == true ]]; then
+    KICKSTART_FILE="almalinux-live-$(echo "${DESKTOP_ENV}" | tr '[:upper:]' '[:lower:]')-nvidia.ks"
+else
+    KICKSTART_FILE="almalinux-live-$(echo "${DESKTOP_ENV}" | tr '[:upper:]' '[:lower:]').ks"
+fi
 KICKSTART_PATH="./kickstarts/${VERSION_MAJOR}/${ARCH}/${KICKSTART_FILE}"
 
 # Check if we're building Kitten with date stamp
+NVIDIA_SUFFIX=""
+if [[ "${WITH_NVIDIA}" == true ]]; then
+    NVIDIA_SUFFIX="-NVIDIA"
+fi
+
 if [[ "${VERSION_MAJOR}" == "10-kitten" ]]; then
-    ISO_NAME="AlmaLinux-Kitten-10-${DATE_STAMP}.${ITERATION}-${ARCH}-Live-${DESKTOP_ENV}.iso"
+    ISO_NAME="AlmaLinux-Kitten-10-${DATE_STAMP}.${ITERATION}-${ARCH}-Live-${DESKTOP_ENV}${NVIDIA_SUFFIX}.iso"
     VOLID="AlmaLinux-10-${ARCH}"
 elif [[ "${VERSION_MAJOR}" == "10" ]]; then
-    ISO_NAME="AlmaLinux-${RELEASEVER}-${ARCH}-Live-${DESKTOP_ENV}.iso"
+    ISO_NAME="AlmaLinux-${RELEASEVER}-${ARCH}-Live-${DESKTOP_ENV}${NVIDIA_SUFFIX}.iso"
     VOLID="AlmaLinux-${RELEASEVER//./_}-${ARCH}" # TODO 'Live' skipped to fit into 32 chars
 else
-    ISO_NAME="AlmaLinux-${RELEASEVER}-${ARCH}-Live-${DESKTOP_ENV}.iso"
+    ISO_NAME="AlmaLinux-${RELEASEVER}-${ARCH}-Live-${DESKTOP_ENV}${NVIDIA_SUFFIX}.iso"
     VOLID="AlmaLinux-${RELEASEVER//./_}-${ARCH}-Live"
+fi
+
+# Define output directory path
+if [[ "${WITH_NVIDIA}" == true ]]; then
+    ISO_RESULT_DIR="${RESULT_DIR}/iso_${VERSION_MAJOR}_${ARCH}_${DESKTOP_ENV}-NVIDIA"
+else
+    ISO_RESULT_DIR="${RESULT_DIR}/iso_${DESKTOP_ENV}"
 fi
 
 # Handle volume ID length (ISO9660 32-char limit)
@@ -242,7 +285,7 @@ if [[ ${#VOLID} -gt 32 ]]; then
 fi
 
 # Create results directory structure
-# Note: Don't create iso_${DESKTOP_ENV} - livemedia-creator expects to create it
+# Note: Don't create ISO_RESULT_DIR - livemedia-creator expects to create it
 mkdir -p "${RESULT_DIR}"
 mkdir -p "${RESULT_DIR}/logs"
 
@@ -267,7 +310,6 @@ fi
 log "Using kickstart: ${KICKSTART_PATH}"
 
 # Check if result directory from previous build exists (livemedia-creator will fail if it does)
-ISO_RESULT_DIR="${RESULT_DIR}/iso_${DESKTOP_ENV}"
 if [[ -d "${ISO_RESULT_DIR}" ]]; then
     warning "Result directory from previous build exists: ${ISO_RESULT_DIR}"
     warning "livemedia-creator will fail if this directory exists."
@@ -306,7 +348,7 @@ fi
 LIVEMEDIA_CMD="livemedia-creator \
 --ks=${KICKSTART_PATH} \
 --no-virt \
---resultdir ${RESULT_DIR}/iso_${DESKTOP_ENV} \
+--resultdir ${ISO_RESULT_DIR} \
 --project \"Live AlmaLinux${CODE_NAME}\" \
 --make-iso \
 --iso-only \
@@ -334,14 +376,14 @@ if eval "${LIVEMEDIA_CMD}"; then
     # Generate checksum
     log "Generating SHA256 checksum..."
     (
-        cd "${RESULT_DIR}/iso_${DESKTOP_ENV}"
+        cd "${ISO_RESULT_DIR}"
         sha256sum "${ISO_NAME}" > "${ISO_NAME}.CHECKSUM"
     )
 
     # Display results
-    ISO_SIZE=$(du -h "${RESULT_DIR}/iso_${DESKTOP_ENV}/${ISO_NAME}" | cut -f1)
-    success "ISO created: ${RESULT_DIR}/iso_${DESKTOP_ENV}/${ISO_NAME} (${ISO_SIZE})"
-    success "Checksum: ${RESULT_DIR}/iso_${DESKTOP_ENV}/${ISO_NAME}.CHECKSUM"
+    ISO_SIZE=$(du -h "${ISO_RESULT_DIR}/${ISO_NAME}" | cut -f1)
+    success "ISO created: ${ISO_RESULT_DIR}/${ISO_NAME} (${ISO_SIZE})"
+    success "Checksum: ${ISO_RESULT_DIR}/${ISO_NAME}.CHECKSUM"
     success "Logs: ${RESULT_DIR}/logs/"
 
     log "Build completed at: $(date)"

--- a/build-livemedia.sh
+++ b/build-livemedia.sh
@@ -312,9 +312,8 @@ log "Using kickstart: ${KICKSTART_PATH}"
 # Check if result directory from previous build exists (livemedia-creator will fail if it does)
 if [[ -d "${ISO_RESULT_DIR}" ]]; then
     warning "Result directory from previous build exists: ${ISO_RESULT_DIR}"
-    warning "livemedia-creator will fail if this directory exists."
-    warning "Please remove it manually: rm -rf \"${ISO_RESULT_DIR}\""
-    error "Cannot proceed with existing result directory"
+    log "Automatically removing old result directory to proceed..."
+    rm -rf "${ISO_RESULT_DIR}"
 fi
 
 # Check if running as root

--- a/kickstarts/10-kitten/aarch64/almalinux-live-gnome-nvidia.ks
+++ b/kickstarts/10-kitten/aarch64/almalinux-live-gnome-nvidia.ks
@@ -1,0 +1,261 @@
+# AlmaLinux Live Media (Beta - experimental), with optional install option.
+# Build: sudo livecd-creator --cache=~/livecd-creator/package-cache -c almalinux-8-live-gnome.ks -f AlmaLinux-8-Live-gnome
+# X Window System configuration information
+xconfig  --startxonboot
+# Keyboard layouts
+keyboard 'us'
+
+# System timezone
+timezone US/Eastern
+# System language
+lang en_US.UTF-8
+# Firewall configuration
+firewall --enabled --service=mdns
+
+# Repos
+url --url=https://kitten.repo.almalinux.org/10-kitten/BaseOS/$basearch/os/
+repo --name="appstream" --baseurl=https://kitten.repo.almalinux.org/10-kitten/AppStream/$basearch/os/
+repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extras-common/$basearch/os/
+repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/$basearch/os/
+repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
+repo --name="almalinux-nvidia" --baseurl="https://nvidia.repo.almalinux.org/cuda/10/$basearch/"
+
+# Network information
+network --activate --bootproto=dhcp --device=link --onboot=on
+
+# SELinux configuration
+selinux --enforcing
+
+# System services
+services --disabled="sshd" --enabled="NetworkManager,ModemManager"
+
+# livemedia-creator modifications.
+shutdown
+# System bootloader configuration
+bootloader --location=none
+# Clear blank disks or all existing partitions
+clearpart --all --initlabel
+rootpw rootme
+# Disk partitioning information
+part / --size=10238
+
+
+%post --nochroot
+# Back up original resolv.conf in chroot if it exists
+if [ -L $ANA_INSTALL_PATH/etc/resolv.conf ]; then
+    readlink $ANA_INSTALL_PATH/etc/resolv.conf > $ANA_INSTALL_PATH/etc/resolv.conf.orig_link
+    rm -f $ANA_INSTALL_PATH/etc/resolv.conf
+elif [ -f $ANA_INSTALL_PATH/etc/resolv.conf ]; then
+    cp -p $ANA_INSTALL_PATH/etc/resolv.conf $ANA_INSTALL_PATH/etc/resolv.conf.orig
+    rm -f $ANA_INSTALL_PATH/etc/resolv.conf
+else
+    touch $ANA_INSTALL_PATH/etc/resolv.conf.orig_none
+fi
+
+# Copy host DNS configuration to chroot to enable package downloads in %post
+cat /etc/resolv.conf > $ANA_INSTALL_PATH/etc/resolv.conf
+%end
+
+%post
+# Record all running process PIDs at the start of %post to identify background daemons
+INITIAL_PIDS=$(ps -A -o pid=)
+
+# Tell DNF not to use system dbus/user daemons during the live install phase
+export DNF_NO_PLUGINS=1
+
+# Enable livesys services
+systemctl enable livesys.service
+systemctl enable livesys-late.service
+
+# enable tmpfs for /tmp
+systemctl enable tmp.mount
+
+# make it so that we don't do writing to the overlay for things which
+# are just tmpdirs/caches
+# note https://bugzilla.redhat.com/show_bug.cgi?id=1135475
+cat >> /etc/fstab << EOF
+vartmp   /var/tmp    tmpfs   defaults   0  0
+EOF
+
+# work around for poor key import UI in PackageKit
+rm -f /var/lib/rpm/__db*
+# import AlmaLinux PGP key
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
+echo "Packages within this LiveCD"
+rpm -qa
+# Note that running rpm recreates the rpm db files which aren't needed or wanted
+rm -f /var/lib/rpm/__db*
+
+# go ahead and pre-make the man -k cache (#455968)
+/usr/bin/mandb
+
+# make sure there aren't core files lying around
+rm -f /core*
+
+# convince readahead not to collect
+# FIXME: for systemd
+
+echo 'File created by kickstart. See systemd-update-done.service(8).' \
+    | tee /etc/.updated >/var/.updated
+
+# Remove random-seed
+rm /var/lib/systemd/random-seed
+
+# Remove the rescue kernel and image to save space
+# Installation will recreate these on the target
+rm -f /boot/*-rescue*
+
+# Disable network service here, as doing it in the services line
+# fails due to RHBZ #1369794
+systemctl disable network
+
+# Remove machine-id on pre generated images
+rm -f /etc/machine-id
+touch /etc/machine-id
+
+# set livesys session type
+sed -i 's/^livesys_session=.*/livesys_session="gnome"/' /etc/sysconfig/livesys
+
+# Workaround to add openvpn user and group in case they didn't added during
+# openvpn package installation
+getent group openvpn &>/dev/null || groupadd -r openvpn
+getent passwd openvpn &>/dev/null || \
+    /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
+        -d /etc/openvpn openvpn
+
+# TODO: To place Firefox into Task Manager
+# This should be removed when upstream fixes the livesys-scripts package
+sed -i  's/org.mozilla.firefox.desktop/firefox.desktop/g' /usr/libexec/livesys/sessions.d/livesys-gnome
+
+# Install NVIDIA drivers here to avoid %pretrans /bin/sh dependency issue during image build.
+# Install them in %post after the base system is created and /bin/sh exists.
+dnf install -y --enablerepo=almalinux-nvidia --enablerepo=crb nvidia-open libva-nvidia-driver
+
+# Restore original resolv.conf configuration
+if [ -f /etc/resolv.conf.orig_link ]; then
+    ORIG_TARGET=$(cat /etc/resolv.conf.orig_link)
+    rm -f /etc/resolv.conf /etc/resolv.conf.orig_link
+    ln -sf "$ORIG_TARGET" /etc/resolv.conf
+elif [ -f /etc/resolv.conf.orig ]; then
+    mv -f /etc/resolv.conf.orig /etc/resolv.conf
+elif [ -f /etc/resolv.conf.orig_none ]; then
+    rm -f /etc/resolv.conf /etc/resolv.conf.orig_none
+fi
+
+# Regenerate initramfs to include the NVIDIA kernel modules on the Live Media
+/usr/bin/dracut --regenerate-all --force
+
+# Clean up any background processes started during this %post script to prevent unmount failures
+echo "=== Cleaning up background chroot processes ==="
+CURRENT_PIDS=$(ps -A -o pid=)
+for pid in $CURRENT_PIDS; do
+    if [[ "$pid" != "$$" ]] && [[ "$pid" != "$PPID" ]]; then
+        if ! echo "$INITIAL_PIDS" | grep -q -w "$pid"; then
+            if kill -0 "$pid" 2>/dev/null; then
+                echo "Terminating leftover process PID $pid: $(ps -p "$pid" -o args= || echo "$pid")"
+                kill -9 "$pid" 2>/dev/null || true
+            fi
+        fi
+    fi
+done
+echo "==============================================="
+
+%end
+
+# Packages
+%packages
+# Explicitly specified mandatory packages
+kernel
+kernel-modules
+kernel-modules-extra
+
+# The point of a live image is to install
+anaconda
+anaconda-install-env-deps
+anaconda-live
+@anaconda-tools
+# Anaconda has a weak dep on this and we don't want it on livecds, see
+# https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD
+-fcoe-utils
+-sdubby
+
+# Need aajohan-comfortaa-fonts for the SVG rnotes images
+#aajohan-comfortaa-fonts
+
+# Without this, initramfs generation during live image creation fails: #1242586
+dracut-live
+
+# anaconda needs the locales available to run for different locales
+glibc-all-langpacks
+
+# provide the livesys scripts
+livesys-scripts
+
+# libreoffice group
+#@office-suite
+
+# internet-browser group
+firefox
+
+# Workstation environment group (mandatory)
+@core
+@standard
+#@base-x
+@fonts
+@guest-desktop-agents
+@hardware-support
+@multimedia
+@networkmanager-submodules
+@print-client
+
+# Workstation environment group (optional)
+#@backup-client
+@headless-management
+# internet-applications group
+#evolution
+#evolution-ews
+#evolution-help
+#evolution-mapi
+#hexchat
+thunderbird
+@remote-desktop-clients
+@smart-card
+
+# GNOME specific
+@gnome-desktop
+#@gnome-apps
+
+# Exclude unwanted packages from @anaconda-tools group
+-gfs2-utils
+-reiserfs-utils
+
+# Workstation specific
+bash-color-prompt
+exfatprogs
+fpaste
+iptstate
+nss-mdns
+#ntfs-3g
+#ntfsprogs
+policycoreutils-python-utils
+psmisc
+python3-dnf-plugin-system-upgrade
+toolbox
+#unoconv
+uresourced
+whois
+
+# EPEL repo
+epel-release
+
+# OpenVPN
+openvpn
+NetworkManager-openvpn
+NetworkManager-openvpn-gnome
+
+# minimization
+-hplip
+# Official NVIDIA GPU Driver Stack
+almalinux-release-nvidia-driver
+
+%end

--- a/kickstarts/10-kitten/aarch64/almalinux-live-kde-nvidia.ks
+++ b/kickstarts/10-kitten/aarch64/almalinux-live-kde-nvidia.ks
@@ -1,0 +1,274 @@
+#version=DEVEL
+# X Window System configuration information
+xconfig  --startxonboot
+# Keyboard layouts
+keyboard 'us'
+# Root password
+rootpw --plaintext rootme
+# System language
+lang en_US.UTF-8
+# Shutdown after installation
+shutdown
+# System timezone
+timezone US/Eastern
+# Network information
+network  --bootproto=dhcp --device=link --activate
+
+# Repos
+url --url=https://kitten.repo.almalinux.org/10-kitten/BaseOS/$basearch/os/
+repo --name="appstream" --baseurl=https://kitten.repo.almalinux.org/10-kitten/AppStream/$basearch/os/
+repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extras-common/$basearch/os/
+repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/$basearch/os/
+repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
+repo --name="almalinux-nvidia" --baseurl="https://nvidia.repo.almalinux.org/cuda/10/$basearch/"
+
+# Firewall configuration
+firewall --enabled --service=mdns
+# SELinux configuration
+selinux --enforcing
+
+# System services
+services --disabled="sshd" --enabled="NetworkManager,ModemManager"
+# System bootloader configuration
+bootloader --location=none
+# Clear the Master Boot Record
+zerombr
+# Partition clearing information
+clearpart --all --initlabel
+# Disk partitioning information
+part / --size=10238
+
+
+%post --nochroot
+# Back up original resolv.conf in chroot if it exists
+if [ -L $ANA_INSTALL_PATH/etc/resolv.conf ]; then
+    readlink $ANA_INSTALL_PATH/etc/resolv.conf > $ANA_INSTALL_PATH/etc/resolv.conf.orig_link
+    rm -f $ANA_INSTALL_PATH/etc/resolv.conf
+elif [ -f $ANA_INSTALL_PATH/etc/resolv.conf ]; then
+    cp -p $ANA_INSTALL_PATH/etc/resolv.conf $ANA_INSTALL_PATH/etc/resolv.conf.orig
+    rm -f $ANA_INSTALL_PATH/etc/resolv.conf
+else
+    touch $ANA_INSTALL_PATH/etc/resolv.conf.orig_none
+fi
+
+# Copy host DNS configuration to chroot to enable package downloads in %post
+cat /etc/resolv.conf > $ANA_INSTALL_PATH/etc/resolv.conf
+%end
+
+%post
+# Record all running process PIDs at the start of %post to identify background daemons
+INITIAL_PIDS=$(ps -A -o pid=)
+
+# Tell DNF not to use system dbus/user daemons during the live install phase
+export DNF_NO_PLUGINS=1
+
+
+# Enable livesys services
+systemctl enable livesys.service
+systemctl enable livesys-late.service
+
+# Enable sddm since EPEL packages it disabled by default
+systemctl enable sddm.service
+
+# enable tmpfs for /tmp
+systemctl enable tmp.mount
+
+# make it so that we don't do writing to the overlay for things which
+# are just tmpdirs/caches
+# note https://bugzilla.redhat.com/show_bug.cgi?id=1135475
+cat >> /etc/fstab << EOF
+vartmp   /var/tmp    tmpfs   defaults   0  0
+EOF
+
+# work around for poor key import UI in PackageKit
+rm -f /var/lib/rpm/__db*
+# import AlmaLinux PGP key
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
+echo "Packages within this LiveCD"
+rpm -qa
+# Note that running rpm recreates the rpm db files which aren't needed or wanted
+rm -f /var/lib/rpm/__db*
+
+# go ahead and pre-make the man -k cache (#455968)
+/usr/bin/mandb
+
+# make sure there aren't core files lying around
+rm -f /core*
+
+# remove random seed, the newly installed instance should make it's own
+rm -f /var/lib/systemd/random-seed
+
+# convince readahead not to collect
+# FIXME: for systemd
+
+echo 'File created by kickstart. See systemd-update-done.service(8).' \
+    | tee /etc/.updated >/var/.updated
+
+# Drop the rescue kernel and initramfs, we don't need them on the live media itself.
+# See bug 1317709
+rm -f /boot/*-rescue*
+
+# Theme wallpapers
+rm -f /usr/share/wallpapers/Fedora
+ln -s Alma-default /usr/share/wallpapers/Fedora
+
+# Login screen theme and wallpapers
+cat <<'EOF'>/etc/sddm.conf.d/kde_settings.conf
+[Theme]
+Current=breeze
+EOF
+sed -i 's#background=.*$#background=/usr/share/backgrounds/almalinux-day.jpg#g' \
+  /usr/share/sddm/themes/breeze/theme.conf
+
+# TODO: revise I and II once installer icon is on the separate package
+# like Fedora does at https://src.fedoraproject.org/rpms/kf6-breeze-icons/c/728493c525b4e4e7be5caccba41f66e8d816ee38
+
+# I. Fix org.fedoraproject.AnacondaInstaller.svg broken symlinks
+cp -a /usr/share/icons/hicolor/scalable/apps/org.fedoraproject.AnacondaInstaller.svg \
+  /usr/share/icons/hicolor/48x48/apps/
+# II. Replace live installer icon for the application and welcome center
+cp -a /usr/share/icons/hicolor/scalable/apps/org.fedoraproject.AnacondaInstaller.svg \
+  /usr/share/icons/hicolor/48x48/apps/org.almalinux.AnacondaInstaller.svg
+sed -i 's#Icon=.*$#Icon=org.almalinux.AnacondaInstaller#g' \
+  /usr/share/applications/liveinst.desktop
+
+# Show liveinst.desktop on desktop and in menu
+sed -i 's/NoDisplay=true/NoDisplay=false/' /usr/share/applications/liveinst.desktop
+mkdir /home/liveuser/Desktop
+cp -a /usr/share/applications/liveinst.desktop /home/liveuser/Desktop/liveinst.desktop
+chmod +x /home/liveuser/Desktop/liveinst.desktop
+
+# Disable network service here, as doing it in the services line
+# fails due to RHBZ #1369794
+systemctl disable network
+
+# Remove machine-id on pre generated images
+rm -f /etc/machine-id
+touch /etc/machine-id
+
+# set livesys session type
+sed -i 's/^livesys_session=.*/livesys_session="kde"/' /etc/sysconfig/livesys
+
+# enable CRB repo
+dnf config-manager --enable crb
+
+# Workaround to add openvpn user and group in case they didn't added during
+# openvpn package installation
+getent group openvpn &>/dev/null || groupadd -r openvpn
+getent passwd openvpn &>/dev/null || \
+    /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
+        -d /etc/openvpn openvpn
+
+
+# Install NVIDIA drivers here to avoid %pretrans /bin/sh dependency issue during image build.
+# Install them in %post after the base system is created and /bin/sh exists.
+dnf install -y --enablerepo=almalinux-nvidia --enablerepo=crb nvidia-open libva-nvidia-driver
+
+# Restore original resolv.conf configuration
+if [ -f /etc/resolv.conf.orig_link ]; then
+    ORIG_TARGET=$(cat /etc/resolv.conf.orig_link)
+    rm -f /etc/resolv.conf /etc/resolv.conf.orig_link
+    ln -sf "$ORIG_TARGET" /etc/resolv.conf
+elif [ -f /etc/resolv.conf.orig ]; then
+    mv -f /etc/resolv.conf.orig /etc/resolv.conf
+elif [ -f /etc/resolv.conf.orig_none ]; then
+    rm -f /etc/resolv.conf /etc/resolv.conf.orig_none
+fi
+
+# Regenerate initramfs to include the NVIDIA kernel modules on the Live Media
+/usr/bin/dracut --regenerate-all --force
+
+# Clean up any background processes started during this %post script to prevent unmount failures
+echo "=== Cleaning up background chroot processes ==="
+CURRENT_PIDS=$(ps -A -o pid=)
+for pid in $CURRENT_PIDS; do
+    if [[ "$pid" != "$$" ]] && [[ "$pid" != "$PPID" ]]; then
+        if ! echo "$INITIAL_PIDS" | grep -q -w "$pid"; then
+            if kill -0 "$pid" 2>/dev/null; then
+                echo "Terminating leftover process PID $pid: $(ps -p "$pid" -o args= || echo "$pid")"
+                kill -9 "$pid" 2>/dev/null || true
+            fi
+        fi
+    fi
+done
+echo "==============================================="
+
+%end
+
+%packages
+# Explicitly specified mandatory packages
+kernel
+kernel-modules
+kernel-modules-extra
+
+# The point of a live image is to install
+anaconda
+anaconda-install-env-deps
+anaconda-live
+@anaconda-tools
+# Anaconda has a weak dep on this and we don't want it on livecds, see
+# https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD
+-fcoe-utils
+-sdubby
+
+# Need aajohan-comfortaa-fonts for the SVG rnotes images
+#aajohan-comfortaa-fonts
+
+# Plymouth bgrt/spinner instead of text theme
+plymouth-system-theme
+
+# Without this, initramfs generation during live image creation fails: #1242586
+dracut-live
+
+# anaconda needs the locales available to run for different locales
+glibc-all-langpacks
+
+# provide the livesys scripts
+livesys-scripts
+
+# libreoffice group
+#@office-suite
+
+# internet-browser group
+firefox
+
+# KDE specific
+@dial-up
+@standard
+
+# install env-group to resolve RhBug:1891500
+@^kde-desktop-environment
+
+@kde-apps
+@kde-media
+
+# drop tracker stuff pulled in by gtk3 (pagureio:fedora-kde/SIG#124)
+-tracker-miners
+-tracker
+
+# Additional packages that are not default in kde-* groups, but useful
+fuse
+
+# EPEL repo
+epel-release
+
+# OpenVPN
+openvpn
+NetworkManager-openvpn
+
+### space issues
+-ktorrent			# kget has also basic torrent features (~3 megs)
+-digikam			# digikam has duplicate functionality with gwenview (~28 megs)
+-kipi-plugins			# ~8 megs + drags in Marble
+-krusader			# ~4 megs
+-k3b				# ~15 megs
+
+# minimization
+-hplip
+
+# Add alsa-sof-firmware to all images PR #51
+alsa-sof-firmware
+# Official NVIDIA GPU Driver Stack
+almalinux-release-nvidia-driver
+
+%end

--- a/kickstarts/10-kitten/x86_64/almalinux-live-gnome-nvidia.ks
+++ b/kickstarts/10-kitten/x86_64/almalinux-live-gnome-nvidia.ks
@@ -1,0 +1,243 @@
+# AlmaLinux Live Media (Beta - experimental), with optional install option.
+# Build: sudo livecd-creator --cache=~/livecd-creator/package-cache -c almalinux-8-live-gnome.ks -f AlmaLinux-8-Live-gnome
+# X Window System configuration information
+xconfig  --startxonboot
+# Keyboard layouts
+keyboard 'us'
+
+# System timezone
+timezone US/Eastern
+# System language
+lang en_US.UTF-8
+# Firewall configuration
+firewall --enabled --service=mdns
+
+# Repos
+url --url=https://kitten.repo.almalinux.org/10-kitten/BaseOS/$basearch/os/
+repo --name="appstream" --baseurl=https://kitten.repo.almalinux.org/10-kitten/AppStream/$basearch/os/
+repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extras-common/$basearch/os/
+repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/$basearch/os/
+repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
+repo --name="almalinux-nvidia" --baseurl="https://nvidia.repo.almalinux.org/cuda/10/$basearch/"
+
+# Network information
+network --activate --bootproto=dhcp --device=link --onboot=on
+
+# SELinux configuration
+selinux --enforcing
+
+# System services
+services --disabled="sshd" --enabled="NetworkManager,ModemManager"
+
+# livemedia-creator modifications.
+shutdown
+# System bootloader configuration
+bootloader --location=none
+# Clear blank disks or all existing partitions
+clearpart --all --initlabel
+rootpw rootme
+# Disk partitioning information
+part / --size=10238
+
+
+%post --nochroot
+# Back up original resolv.conf in chroot if it exists
+if [ -L $ANA_INSTALL_PATH/etc/resolv.conf ]; then
+    readlink $ANA_INSTALL_PATH/etc/resolv.conf > $ANA_INSTALL_PATH/etc/resolv.conf.orig_link
+    rm -f $ANA_INSTALL_PATH/etc/resolv.conf
+elif [ -f $ANA_INSTALL_PATH/etc/resolv.conf ]; then
+    cp -p $ANA_INSTALL_PATH/etc/resolv.conf $ANA_INSTALL_PATH/etc/resolv.conf.orig
+    rm -f $ANA_INSTALL_PATH/etc/resolv.conf
+else
+    touch $ANA_INSTALL_PATH/etc/resolv.conf.orig_none
+fi
+
+# Copy host DNS configuration to chroot to enable package downloads in %post
+cat /etc/resolv.conf > $ANA_INSTALL_PATH/etc/resolv.conf
+%end
+
+%post
+# Record all running process PIDs at the start of %post to identify background daemons
+INITIAL_PIDS=$(ps -A -o pid=)
+
+# Tell DNF not to use system dbus/user daemons during the live install phase
+export DNF_NO_PLUGINS=1
+
+# Enable livesys services
+systemctl enable livesys.service
+systemctl enable livesys-late.service
+
+# enable tmpfs for /tmp
+systemctl enable tmp.mount
+
+# make it so that we don't do writing to the overlay for things which
+# are just tmpdirs/caches
+# note https://bugzilla.redhat.com/show_bug.cgi?id=1135475
+cat >> /etc/fstab << EOF
+vartmp   /var/tmp    tmpfs   defaults   0  0
+EOF
+
+# work around for poor key import UI in PackageKit
+rm -f /var/lib/rpm/__db*
+# import AlmaLinux PGP key
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
+echo "Packages within this LiveCD"
+rpm -qa
+# Note that running rpm recreates the rpm db files which aren't needed or wanted
+rm -f /var/lib/rpm/__db*
+
+# go ahead and pre-make the man -k cache (#455968)
+/usr/bin/mandb
+
+# make sure there aren't core files lying around
+rm -f /core*
+
+# convince readahead not to collect
+# FIXME: for systemd
+
+echo 'File created by kickstart. See systemd-update-done.service(8).' \
+    | tee /etc/.updated >/var/.updated
+
+# Remove random-seed
+rm /var/lib/systemd/random-seed
+
+# Remove the rescue kernel and image to save space
+# Installation will recreate these on the target
+rm -f /boot/*-rescue*
+
+# Disable network service here, as doing it in the services line
+# fails due to RHBZ #1369794
+systemctl disable network
+
+# Remove machine-id on pre generated images
+rm -f /etc/machine-id
+touch /etc/machine-id
+
+# set livesys session type
+sed -i 's/^livesys_session=.*/livesys_session="gnome"/' /etc/sysconfig/livesys
+
+# Workaround to add openvpn user and group in case they didn't added during
+# openvpn package installation
+getent group openvpn &>/dev/null || groupadd -r openvpn
+getent passwd openvpn &>/dev/null || \
+    /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
+        -d /etc/openvpn openvpn
+
+# TODO: To place Firefox into Task Manager
+# This should be removed when upstream fixes the livesys-scripts package
+sed -i  's/org.mozilla.firefox.desktop/firefox.desktop/g' /usr/libexec/livesys/sessions.d/livesys-gnome
+
+# Install NVIDIA drivers here to avoid %pretrans /bin/sh dependency issue during image build.
+# Install them in %post after the base system is created and /bin/sh exists.
+dnf install -y --enablerepo=almalinux-nvidia --enablerepo=crb nvidia-open libva-nvidia-driver
+
+# Restore original resolv.conf configuration
+if [ -f /etc/resolv.conf.orig_link ]; then
+    ORIG_TARGET=$(cat /etc/resolv.conf.orig_link)
+    rm -f /etc/resolv.conf /etc/resolv.conf.orig_link
+    ln -sf "$ORIG_TARGET" /etc/resolv.conf
+elif [ -f /etc/resolv.conf.orig ]; then
+    mv -f /etc/resolv.conf.orig /etc/resolv.conf
+elif [ -f /etc/resolv.conf.orig_none ]; then
+    rm -f /etc/resolv.conf /etc/resolv.conf.orig_none
+fi
+
+# Regenerate initramfs to include the NVIDIA kernel modules on the Live Media
+/usr/bin/dracut --regenerate-all --force
+
+# Clean up any background processes started during this %post script to prevent unmount failures
+echo "=== Cleaning up background chroot processes ==="
+CURRENT_PIDS=$(ps -A -o pid=)
+for pid in $CURRENT_PIDS; do
+    if [[ "$pid" != "$$" ]] && [[ "$pid" != "$PPID" ]]; then
+        if ! echo "$INITIAL_PIDS" | grep -q -w "$pid"; then
+            if kill -0 "$pid" 2>/dev/null; then
+                echo "Terminating leftover process PID $pid: $(ps -p "$pid" -o args= || echo "$pid")"
+                kill -9 "$pid" 2>/dev/null || true
+            fi
+        fi
+    fi
+done
+echo "==============================================="
+
+%end
+
+# Packages
+%packages
+# Explicitly specified mandatory packages
+kernel
+kernel-modules
+kernel-modules-extra
+
+# The point of a live image is to install
+anaconda
+anaconda-install-env-deps
+anaconda-live
+@anaconda-tools
+# Anaconda has a weak dep on this and we don't want it on livecds, see
+# https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD
+-fcoe-utils
+-sdubby
+
+# Need aajohan-comfortaa-fonts for the SVG rnotes images
+#aajohan-comfortaa-fonts
+
+# Without this, initramfs generation during live image creation fails: #1242586
+dracut-live
+
+# anaconda needs the locales available to run for different locales
+glibc-all-langpacks
+
+# provide the livesys scripts
+livesys-scripts
+
+# Mandatory to build media with livemedia-creator
+memtest86+
+
+# libreoffice group
+#@office-suite
+
+# internet-browser group
+firefox
+
+# Workstation environment group
+@^workstation-product-environment
+
+# GNOME specific
+@gnome-desktop
+#@gnome-apps
+
+# Exclude unwanted packages from @anaconda-tools group
+-gfs2-utils
+-reiserfs-utils
+
+# Workstation specific
+bash-color-prompt
+exfatprogs
+fpaste
+iptstate
+nss-mdns
+#ntfs-3g
+#ntfsprogs
+policycoreutils-python-utils
+psmisc
+python3-dnf-plugin-system-upgrade
+toolbox
+#unoconv
+uresourced
+whois
+
+# EPEL repo
+epel-release
+
+# OpenVPN
+openvpn
+NetworkManager-openvpn
+NetworkManager-openvpn-gnome
+
+# minimization
+-hplip
+# Official NVIDIA GPU Driver Stack
+almalinux-release-nvidia-driver
+
+%end

--- a/kickstarts/10-kitten/x86_64/almalinux-live-kde-nvidia.ks
+++ b/kickstarts/10-kitten/x86_64/almalinux-live-kde-nvidia.ks
@@ -1,0 +1,277 @@
+#version=DEVEL
+# X Window System configuration information
+xconfig  --startxonboot
+# Keyboard layouts
+keyboard 'us'
+# Root password
+rootpw --plaintext rootme
+# System language
+lang en_US.UTF-8
+# Shutdown after installation
+shutdown
+# System timezone
+timezone US/Eastern
+# Network information
+network  --bootproto=dhcp --device=link --activate
+
+# Repos
+url --url=https://kitten.repo.almalinux.org/10-kitten/BaseOS/$basearch/os/
+repo --name="appstream" --baseurl=https://kitten.repo.almalinux.org/10-kitten/AppStream/$basearch/os/
+repo --name="extras" --baseurl=https://kitten.repo.almalinux.org/10-kitten/extras-common/$basearch/os/
+repo --name="crb" --baseurl=https://kitten.repo.almalinux.org/10-kitten/CRB/$basearch/os/
+repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10/Everything/$basearch/
+repo --name="almalinux-nvidia" --baseurl="https://nvidia.repo.almalinux.org/cuda/10/$basearch/"
+
+# Firewall configuration
+firewall --enabled --service=mdns
+# SELinux configuration
+selinux --enforcing
+
+# System services
+services --disabled="sshd" --enabled="NetworkManager,ModemManager"
+# System bootloader configuration
+bootloader --location=none
+# Clear the Master Boot Record
+zerombr
+# Partition clearing information
+clearpart --all --initlabel
+# Disk partitioning information
+part / --size=10238
+
+
+%post --nochroot
+# Back up original resolv.conf in chroot if it exists
+if [ -L $ANA_INSTALL_PATH/etc/resolv.conf ]; then
+    readlink $ANA_INSTALL_PATH/etc/resolv.conf > $ANA_INSTALL_PATH/etc/resolv.conf.orig_link
+    rm -f $ANA_INSTALL_PATH/etc/resolv.conf
+elif [ -f $ANA_INSTALL_PATH/etc/resolv.conf ]; then
+    cp -p $ANA_INSTALL_PATH/etc/resolv.conf $ANA_INSTALL_PATH/etc/resolv.conf.orig
+    rm -f $ANA_INSTALL_PATH/etc/resolv.conf
+else
+    touch $ANA_INSTALL_PATH/etc/resolv.conf.orig_none
+fi
+
+# Copy host DNS configuration to chroot to enable package downloads in %post
+cat /etc/resolv.conf > $ANA_INSTALL_PATH/etc/resolv.conf
+%end
+
+%post
+# Record all running process PIDs at the start of %post to identify background daemons
+INITIAL_PIDS=$(ps -A -o pid=)
+
+# Tell DNF not to use system dbus/user daemons during the live install phase
+export DNF_NO_PLUGINS=1
+
+
+# Enable livesys services
+systemctl enable livesys.service
+systemctl enable livesys-late.service
+
+# Enable sddm since EPEL packages it disabled by default
+systemctl enable sddm.service
+
+# enable tmpfs for /tmp
+systemctl enable tmp.mount
+
+# make it so that we don't do writing to the overlay for things which
+# are just tmpdirs/caches
+# note https://bugzilla.redhat.com/show_bug.cgi?id=1135475
+cat >> /etc/fstab << EOF
+vartmp   /var/tmp    tmpfs   defaults   0  0
+EOF
+
+# work around for poor key import UI in PackageKit
+rm -f /var/lib/rpm/__db*
+# import AlmaLinux PGP key
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
+echo "Packages within this LiveCD"
+rpm -qa
+# Note that running rpm recreates the rpm db files which aren't needed or wanted
+rm -f /var/lib/rpm/__db*
+
+# go ahead and pre-make the man -k cache (#455968)
+/usr/bin/mandb
+
+# make sure there aren't core files lying around
+rm -f /core*
+
+# remove random seed, the newly installed instance should make it's own
+rm -f /var/lib/systemd/random-seed
+
+# convince readahead not to collect
+# FIXME: for systemd
+
+echo 'File created by kickstart. See systemd-update-done.service(8).' \
+    | tee /etc/.updated >/var/.updated
+
+# Drop the rescue kernel and initramfs, we don't need them on the live media itself.
+# See bug 1317709
+rm -f /boot/*-rescue*
+
+# Theme wallpapers
+rm -f /usr/share/wallpapers/Fedora
+ln -s Alma-default /usr/share/wallpapers/Fedora
+
+# Login screen theme and wallpapers
+cat <<'EOF'>/etc/sddm.conf.d/kde_settings.conf
+[Theme]
+Current=breeze
+EOF
+sed -i 's#background=.*$#background=/usr/share/backgrounds/almalinux-day.jpg#g' \
+  /usr/share/sddm/themes/breeze/theme.conf
+
+# TODO: revise I and II once installer icon is on the separate package
+# like Fedora does at https://src.fedoraproject.org/rpms/kf6-breeze-icons/c/728493c525b4e4e7be5caccba41f66e8d816ee38
+
+# I. Fix org.fedoraproject.AnacondaInstaller.svg broken symlinks
+cp -a /usr/share/icons/hicolor/scalable/apps/org.fedoraproject.AnacondaInstaller.svg \
+  /usr/share/icons/hicolor/48x48/apps/
+# II. Replace live installer icon for the application and welcome center
+cp -a /usr/share/icons/hicolor/scalable/apps/org.fedoraproject.AnacondaInstaller.svg \
+  /usr/share/icons/hicolor/48x48/apps/org.almalinux.AnacondaInstaller.svg
+sed -i 's#Icon=.*$#Icon=org.almalinux.AnacondaInstaller#g' \
+  /usr/share/applications/liveinst.desktop
+
+# Show liveinst.desktop on desktop and in menu
+sed -i 's/NoDisplay=true/NoDisplay=false/' /usr/share/applications/liveinst.desktop
+mkdir /home/liveuser/Desktop
+cp -a /usr/share/applications/liveinst.desktop /home/liveuser/Desktop/liveinst.desktop
+chmod +x /home/liveuser/Desktop/liveinst.desktop
+
+# Disable network service here, as doing it in the services line
+# fails due to RHBZ #1369794
+systemctl disable network
+
+# Remove machine-id on pre generated images
+rm -f /etc/machine-id
+touch /etc/machine-id
+
+# set livesys session type
+sed -i 's/^livesys_session=.*/livesys_session="kde"/' /etc/sysconfig/livesys
+
+# enable CRB repo
+dnf config-manager --enable crb
+
+# Workaround to add openvpn user and group in case they didn't added during
+# openvpn package installation
+getent group openvpn &>/dev/null || groupadd -r openvpn
+getent passwd openvpn &>/dev/null || \
+    /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
+        -d /etc/openvpn openvpn
+
+
+# Install NVIDIA drivers here to avoid %pretrans /bin/sh dependency issue during image build.
+# Install them in %post after the base system is created and /bin/sh exists.
+dnf install -y --enablerepo=almalinux-nvidia --enablerepo=crb nvidia-open libva-nvidia-driver
+
+# Restore original resolv.conf configuration
+if [ -f /etc/resolv.conf.orig_link ]; then
+    ORIG_TARGET=$(cat /etc/resolv.conf.orig_link)
+    rm -f /etc/resolv.conf /etc/resolv.conf.orig_link
+    ln -sf "$ORIG_TARGET" /etc/resolv.conf
+elif [ -f /etc/resolv.conf.orig ]; then
+    mv -f /etc/resolv.conf.orig /etc/resolv.conf
+elif [ -f /etc/resolv.conf.orig_none ]; then
+    rm -f /etc/resolv.conf /etc/resolv.conf.orig_none
+fi
+
+# Regenerate initramfs to include the NVIDIA kernel modules on the Live Media
+/usr/bin/dracut --regenerate-all --force
+
+# Clean up any background processes started during this %post script to prevent unmount failures
+echo "=== Cleaning up background chroot processes ==="
+CURRENT_PIDS=$(ps -A -o pid=)
+for pid in $CURRENT_PIDS; do
+    if [[ "$pid" != "$$" ]] && [[ "$pid" != "$PPID" ]]; then
+        if ! echo "$INITIAL_PIDS" | grep -q -w "$pid"; then
+            if kill -0 "$pid" 2>/dev/null; then
+                echo "Terminating leftover process PID $pid: $(ps -p "$pid" -o args= || echo "$pid")"
+                kill -9 "$pid" 2>/dev/null || true
+            fi
+        fi
+    fi
+done
+echo "==============================================="
+
+%end
+
+%packages
+# Explicitly specified mandatory packages
+kernel
+kernel-modules
+kernel-modules-extra
+
+# The point of a live image is to install
+anaconda
+anaconda-install-env-deps
+anaconda-live
+@anaconda-tools
+# Anaconda has a weak dep on this and we don't want it on livecds, see
+# https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD
+-fcoe-utils
+-sdubby
+
+# Need aajohan-comfortaa-fonts for the SVG rnotes images
+#aajohan-comfortaa-fonts
+
+# Plymouth bgrt/spinner instead of text theme
+plymouth-system-theme
+
+# Without this, initramfs generation during live image creation fails: #1242586
+dracut-live
+
+# anaconda needs the locales available to run for different locales
+glibc-all-langpacks
+
+# provide the livesys scripts
+livesys-scripts
+
+# Mandatory to build media with livemedia-creator
+memtest86+
+
+# libreoffice group
+#@office-suite
+
+# internet-browser group
+firefox
+
+# KDE specific
+@dial-up
+@standard
+
+# install env-group to resolve RhBug:1891500
+@^kde-desktop-environment
+
+@kde-apps
+@kde-media
+
+# drop tracker stuff pulled in by gtk3 (pagureio:fedora-kde/SIG#124)
+-tracker-miners
+-tracker
+
+# Additional packages that are not default in kde-* groups, but useful
+fuse
+
+# EPEL repo
+epel-release
+
+# OpenVPN
+openvpn
+NetworkManager-openvpn
+
+### space issues
+-ktorrent			# kget has also basic torrent features (~3 megs)
+-digikam			# digikam has duplicate functionality with gwenview (~28 megs)
+-kipi-plugins			# ~8 megs + drags in Marble
+-krusader			# ~4 megs
+-k3b				# ~15 megs
+
+# minimization
+-hplip
+
+# Add alsa-sof-firmware to all images PR #51
+alsa-sof-firmware
+# Official NVIDIA GPU Driver Stack
+almalinux-release-nvidia-driver
+
+%end

--- a/kickstarts/10/aarch64/almalinux-live-gnome-nvidia.ks
+++ b/kickstarts/10/aarch64/almalinux-live-gnome-nvidia.ks
@@ -1,0 +1,261 @@
+# AlmaLinux Live Media (Beta - experimental), with optional install option.
+# Build: sudo livecd-creator --cache=~/livecd-creator/package-cache -c almalinux-8-live-gnome.ks -f AlmaLinux-8-Live-gnome
+# X Window System configuration information
+xconfig  --startxonboot
+# Keyboard layouts
+keyboard 'us'
+
+# System timezone
+timezone US/Eastern
+# System language
+lang en_US.UTF-8
+# Firewall configuration
+firewall --enabled --service=mdns
+
+# Repos
+url --url=https://repo.almalinux.org/almalinux/10/BaseOS/$basearch/os/
+repo --name="appstream" --baseurl=https://repo.almalinux.org/almalinux/10/AppStream/$basearch/os/
+repo --name="extras" --baseurl=https://repo.almalinux.org/almalinux/10/extras/$basearch/os/
+repo --name="crb" --baseurl=https://repo.almalinux.org/almalinux/10/CRB/$basearch/os/
+repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10z/Everything/$basearch/
+repo --name="almalinux-nvidia" --baseurl="https://nvidia.repo.almalinux.org/cuda/10/$basearch/"
+
+# Network information
+network --activate --bootproto=dhcp --device=link --onboot=on
+
+# SELinux configuration
+selinux --enforcing
+
+# System services
+services --disabled="sshd" --enabled="NetworkManager,ModemManager"
+
+# livemedia-creator modifications.
+shutdown
+# System bootloader configuration
+bootloader --location=none
+# Clear blank disks or all existing partitions
+clearpart --all --initlabel
+rootpw rootme
+# Disk partitioning information
+part / --size=10238
+
+
+%post --nochroot
+# Back up original resolv.conf in chroot if it exists
+if [ -L $ANA_INSTALL_PATH/etc/resolv.conf ]; then
+    readlink $ANA_INSTALL_PATH/etc/resolv.conf > $ANA_INSTALL_PATH/etc/resolv.conf.orig_link
+    rm -f $ANA_INSTALL_PATH/etc/resolv.conf
+elif [ -f $ANA_INSTALL_PATH/etc/resolv.conf ]; then
+    cp -p $ANA_INSTALL_PATH/etc/resolv.conf $ANA_INSTALL_PATH/etc/resolv.conf.orig
+    rm -f $ANA_INSTALL_PATH/etc/resolv.conf
+else
+    touch $ANA_INSTALL_PATH/etc/resolv.conf.orig_none
+fi
+
+# Copy host DNS configuration to chroot to enable package downloads in %post
+cat /etc/resolv.conf > $ANA_INSTALL_PATH/etc/resolv.conf
+%end
+
+%post
+# Record all running process PIDs at the start of %post to identify background daemons
+INITIAL_PIDS=$(ps -A -o pid=)
+
+# Tell DNF not to use system dbus/user daemons during the live install phase
+export DNF_NO_PLUGINS=1
+
+# Enable livesys services
+systemctl enable livesys.service
+systemctl enable livesys-late.service
+
+# enable tmpfs for /tmp
+systemctl enable tmp.mount
+
+# make it so that we don't do writing to the overlay for things which
+# are just tmpdirs/caches
+# note https://bugzilla.redhat.com/show_bug.cgi?id=1135475
+cat >> /etc/fstab << EOF
+vartmp   /var/tmp    tmpfs   defaults   0  0
+EOF
+
+# work around for poor key import UI in PackageKit
+rm -f /var/lib/rpm/__db*
+# import AlmaLinux PGP key
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
+echo "Packages within this LiveCD"
+rpm -qa
+# Note that running rpm recreates the rpm db files which aren't needed or wanted
+rm -f /var/lib/rpm/__db*
+
+# go ahead and pre-make the man -k cache (#455968)
+/usr/bin/mandb
+
+# make sure there aren't core files lying around
+rm -f /core*
+
+# convince readahead not to collect
+# FIXME: for systemd
+
+echo 'File created by kickstart. See systemd-update-done.service(8).' \
+    | tee /etc/.updated >/var/.updated
+
+# Remove random-seed
+rm /var/lib/systemd/random-seed
+
+# Remove the rescue kernel and image to save space
+# Installation will recreate these on the target
+rm -f /boot/*-rescue*
+
+# Disable network service here, as doing it in the services line
+# fails due to RHBZ #1369794
+systemctl disable network
+
+# Remove machine-id on pre generated images
+rm -f /etc/machine-id
+touch /etc/machine-id
+
+# set livesys session type
+sed -i 's/^livesys_session=.*/livesys_session="gnome"/' /etc/sysconfig/livesys
+
+# Workaround to add openvpn user and group in case they didn't added during
+# openvpn package installation
+getent group openvpn &>/dev/null || groupadd -r openvpn
+getent passwd openvpn &>/dev/null || \
+    /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
+        -d /etc/openvpn openvpn
+
+# TODO: To place Firefox into Task Manager
+# This should be removed when upstream fixes the livesys-scripts package
+sed -i  's/org.mozilla.firefox.desktop/firefox.desktop/g' /usr/libexec/livesys/sessions.d/livesys-gnome
+
+# Install NVIDIA drivers here to avoid %pretrans /bin/sh dependency issue during image build.
+# Install them in %post after the base system is created and /bin/sh exists.
+dnf install -y --enablerepo=almalinux-nvidia --enablerepo=crb nvidia-open libva-nvidia-driver
+
+# Restore original resolv.conf configuration
+if [ -f /etc/resolv.conf.orig_link ]; then
+    ORIG_TARGET=$(cat /etc/resolv.conf.orig_link)
+    rm -f /etc/resolv.conf /etc/resolv.conf.orig_link
+    ln -sf "$ORIG_TARGET" /etc/resolv.conf
+elif [ -f /etc/resolv.conf.orig ]; then
+    mv -f /etc/resolv.conf.orig /etc/resolv.conf
+elif [ -f /etc/resolv.conf.orig_none ]; then
+    rm -f /etc/resolv.conf /etc/resolv.conf.orig_none
+fi
+
+# Regenerate initramfs to include the NVIDIA kernel modules on the Live Media
+/usr/bin/dracut --regenerate-all --force
+
+# Clean up any background processes started during this %post script to prevent unmount failures
+echo "=== Cleaning up background chroot processes ==="
+CURRENT_PIDS=$(ps -A -o pid=)
+for pid in $CURRENT_PIDS; do
+    if [[ "$pid" != "$$" ]] && [[ "$pid" != "$PPID" ]]; then
+        if ! echo "$INITIAL_PIDS" | grep -q -w "$pid"; then
+            if kill -0 "$pid" 2>/dev/null; then
+                echo "Terminating leftover process PID $pid: $(ps -p "$pid" -o args= || echo "$pid")"
+                kill -9 "$pid" 2>/dev/null || true
+            fi
+        fi
+    fi
+done
+echo "==============================================="
+
+%end
+
+# Packages
+%packages
+# Explicitly specified mandatory packages
+kernel
+kernel-modules
+kernel-modules-extra
+
+# The point of a live image is to install
+anaconda
+anaconda-install-env-deps
+anaconda-live
+@anaconda-tools
+# Anaconda has a weak dep on this and we don't want it on livecds, see
+# https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD
+-fcoe-utils
+-sdubby
+
+# Need aajohan-comfortaa-fonts for the SVG rnotes images
+#aajohan-comfortaa-fonts
+
+# Without this, initramfs generation during live image creation fails: #1242586
+dracut-live
+
+# anaconda needs the locales available to run for different locales
+glibc-all-langpacks
+
+# provide the livesys scripts
+livesys-scripts
+
+# libreoffice group
+#@office-suite
+
+# internet-browser group
+firefox
+
+# Workstation environment group (mandatory)
+@core
+@standard
+#@base-x
+@fonts
+@guest-desktop-agents
+@hardware-support
+@multimedia
+@networkmanager-submodules
+@print-client
+
+# Workstation environment group (optional)
+#@backup-client
+@headless-management
+# internet-applications group
+#evolution
+#evolution-ews
+#evolution-help
+#evolution-mapi
+#hexchat
+thunderbird
+@remote-desktop-clients
+@smart-card
+
+# GNOME specific
+@gnome-desktop
+#@gnome-apps
+
+# Exclude unwanted packages from @anaconda-tools group
+-gfs2-utils
+-reiserfs-utils
+
+# Workstation specific
+bash-color-prompt
+exfatprogs
+fpaste
+# iptstate
+nss-mdns
+#ntfs-3g
+#ntfsprogs
+policycoreutils-python-utils
+psmisc
+python3-dnf-plugin-system-upgrade
+toolbox
+#unoconv
+uresourced
+whois
+
+# EPEL repo
+epel-release
+
+# OpenVPN
+openvpn
+NetworkManager-openvpn
+NetworkManager-openvpn-gnome
+
+# minimization
+-hplip
+# Official NVIDIA GPU Driver Stack
+almalinux-release-nvidia-driver
+
+%end

--- a/kickstarts/10/aarch64/almalinux-live-kde-nvidia.ks
+++ b/kickstarts/10/aarch64/almalinux-live-kde-nvidia.ks
@@ -1,0 +1,270 @@
+#version=DEVEL
+# X Window System configuration information
+xconfig  --startxonboot
+# Keyboard layouts
+keyboard 'us'
+# Root password
+rootpw --plaintext rootme
+# System language
+lang en_US.UTF-8
+# Shutdown after installation
+shutdown
+# System timezone
+timezone US/Eastern
+# Network information
+network  --bootproto=dhcp --device=link --activate
+
+# Repos
+url --url=https://repo.almalinux.org/almalinux/10/BaseOS/$basearch/os/
+repo --name="appstream" --baseurl=https://repo.almalinux.org/almalinux/10/AppStream/$basearch/os/
+repo --name="extras" --baseurl=https://repo.almalinux.org/almalinux/10/extras/$basearch/os/
+repo --name="crb" --baseurl=https://repo.almalinux.org/almalinux/10/CRB/$basearch/os/
+repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10z/Everything/$basearch/
+repo --name="almalinux-nvidia" --baseurl="https://nvidia.repo.almalinux.org/cuda/10/$basearch/"
+
+# Firewall configuration
+firewall --enabled --service=mdns
+# SELinux configuration
+selinux --enforcing
+
+# System services
+services --disabled="sshd" --enabled="NetworkManager,ModemManager"
+# System bootloader configuration
+bootloader --location=none
+# Clear the Master Boot Record
+zerombr
+# Partition clearing information
+clearpart --all --initlabel
+# Disk partitioning information
+part / --size=10238
+
+
+%post --nochroot
+# Back up original resolv.conf in chroot if it exists
+if [ -L $ANA_INSTALL_PATH/etc/resolv.conf ]; then
+    readlink $ANA_INSTALL_PATH/etc/resolv.conf > $ANA_INSTALL_PATH/etc/resolv.conf.orig_link
+    rm -f $ANA_INSTALL_PATH/etc/resolv.conf
+elif [ -f $ANA_INSTALL_PATH/etc/resolv.conf ]; then
+    cp -p $ANA_INSTALL_PATH/etc/resolv.conf $ANA_INSTALL_PATH/etc/resolv.conf.orig
+    rm -f $ANA_INSTALL_PATH/etc/resolv.conf
+else
+    touch $ANA_INSTALL_PATH/etc/resolv.conf.orig_none
+fi
+
+# Copy host DNS configuration to chroot to enable package downloads in %post
+cat /etc/resolv.conf > $ANA_INSTALL_PATH/etc/resolv.conf
+%end
+
+%post
+# Record all running process PIDs at the start of %post to identify background daemons
+INITIAL_PIDS=$(ps -A -o pid=)
+
+# Tell DNF not to use system dbus/user daemons during the live install phase
+export DNF_NO_PLUGINS=1
+
+
+# Enable livesys services
+systemctl enable livesys.service
+systemctl enable livesys-late.service
+
+# Enable sddm since EPEL packages it disabled by default
+systemctl enable sddm.service
+
+# enable tmpfs for /tmp
+systemctl enable tmp.mount
+
+# make it so that we don't do writing to the overlay for things which
+# are just tmpdirs/caches
+# note https://bugzilla.redhat.com/show_bug.cgi?id=1135475
+cat >> /etc/fstab << EOF
+vartmp   /var/tmp    tmpfs   defaults   0  0
+EOF
+
+# work around for poor key import UI in PackageKit
+rm -f /var/lib/rpm/__db*
+# import AlmaLinux PGP key
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
+echo "Packages within this LiveCD"
+rpm -qa
+# Note that running rpm recreates the rpm db files which aren't needed or wanted
+rm -f /var/lib/rpm/__db*
+
+# go ahead and pre-make the man -k cache (#455968)
+/usr/bin/mandb
+
+# make sure there aren't core files lying around
+rm -f /core*
+
+# remove random seed, the newly installed instance should make it's own
+rm -f /var/lib/systemd/random-seed
+
+# convince readahead not to collect
+# FIXME: for systemd
+
+echo 'File created by kickstart. See systemd-update-done.service(8).' \
+    | tee /etc/.updated >/var/.updated
+
+# Drop the rescue kernel and initramfs, we don't need them on the live media itself.
+# See bug 1317709
+rm -f /boot/*-rescue*
+
+# Login screen theme and wallpapers
+cat <<'EOF'>/etc/sddm.conf.d/kde_settings.conf
+[Theme]
+Current=breeze
+EOF
+sed -i 's#background=.*$#background=/usr/share/backgrounds/almalinux-day.jpg#g' \
+  /usr/share/sddm/themes/breeze/theme.conf
+
+# TODO: revise I and II once installer icon is on the separate package
+# like Fedora does at https://src.fedoraproject.org/rpms/kf6-breeze-icons/c/728493c525b4e4e7be5caccba41f66e8d816ee38
+
+# I. Fix org.fedoraproject.AnacondaInstaller.svg broken symlinks
+cp -a /usr/share/icons/hicolor/scalable/apps/org.fedoraproject.AnacondaInstaller.svg \
+  /usr/share/icons/hicolor/48x48/apps/
+# II. Replace live installer icon for the application and welcome center
+cp -a /usr/share/icons/hicolor/scalable/apps/org.fedoraproject.AnacondaInstaller.svg \
+  /usr/share/icons/hicolor/48x48/apps/org.almalinux.AnacondaInstaller.svg
+sed -i 's#Icon=.*$#Icon=org.almalinux.AnacondaInstaller#g' \
+  /usr/share/applications/liveinst.desktop
+
+# Show liveinst.desktop on desktop and in menu
+sed -i 's/NoDisplay=true/NoDisplay=false/' /usr/share/applications/liveinst.desktop
+mkdir /home/liveuser/Desktop
+cp -a /usr/share/applications/liveinst.desktop /home/liveuser/Desktop/liveinst.desktop
+chmod +x /home/liveuser/Desktop/liveinst.desktop
+
+# Disable network service here, as doing it in the services line
+# fails due to RHBZ #1369794
+systemctl disable network
+
+# Remove machine-id on pre generated images
+rm -f /etc/machine-id
+touch /etc/machine-id
+
+# set livesys session type
+sed -i 's/^livesys_session=.*/livesys_session="kde"/' /etc/sysconfig/livesys
+
+# enable CRB repo
+dnf config-manager --enable crb
+
+# Workaround to add openvpn user and group in case they didn't added during
+# openvpn package installation
+getent group openvpn &>/dev/null || groupadd -r openvpn
+getent passwd openvpn &>/dev/null || \
+    /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
+        -d /etc/openvpn openvpn
+
+
+# Install NVIDIA drivers here to avoid %pretrans /bin/sh dependency issue during image build.
+# Install them in %post after the base system is created and /bin/sh exists.
+dnf install -y --enablerepo=almalinux-nvidia --enablerepo=crb nvidia-open libva-nvidia-driver
+
+# Restore original resolv.conf configuration
+if [ -f /etc/resolv.conf.orig_link ]; then
+    ORIG_TARGET=$(cat /etc/resolv.conf.orig_link)
+    rm -f /etc/resolv.conf /etc/resolv.conf.orig_link
+    ln -sf "$ORIG_TARGET" /etc/resolv.conf
+elif [ -f /etc/resolv.conf.orig ]; then
+    mv -f /etc/resolv.conf.orig /etc/resolv.conf
+elif [ -f /etc/resolv.conf.orig_none ]; then
+    rm -f /etc/resolv.conf /etc/resolv.conf.orig_none
+fi
+
+# Regenerate initramfs to include the NVIDIA kernel modules on the Live Media
+/usr/bin/dracut --regenerate-all --force
+
+# Clean up any background processes started during this %post script to prevent unmount failures
+echo "=== Cleaning up background chroot processes ==="
+CURRENT_PIDS=$(ps -A -o pid=)
+for pid in $CURRENT_PIDS; do
+    if [[ "$pid" != "$$" ]] && [[ "$pid" != "$PPID" ]]; then
+        if ! echo "$INITIAL_PIDS" | grep -q -w "$pid"; then
+            if kill -0 "$pid" 2>/dev/null; then
+                echo "Terminating leftover process PID $pid: $(ps -p "$pid" -o args= || echo "$pid")"
+                kill -9 "$pid" 2>/dev/null || true
+            fi
+        fi
+    fi
+done
+echo "==============================================="
+
+%end
+
+%packages
+# Explicitly specified mandatory packages
+kernel
+kernel-modules
+kernel-modules-extra
+
+# The point of a live image is to install
+anaconda
+anaconda-install-env-deps
+anaconda-live
+@anaconda-tools
+# Anaconda has a weak dep on this and we don't want it on livecds, see
+# https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD
+-fcoe-utils
+-sdubby
+
+# Need aajohan-comfortaa-fonts for the SVG rnotes images
+#aajohan-comfortaa-fonts
+
+# Plymouth bgrt/spinner instead of text theme
+plymouth-system-theme
+
+# Without this, initramfs generation during live image creation fails: #1242586
+dracut-live
+
+# anaconda needs the locales available to run for different locales
+glibc-all-langpacks
+
+# provide the livesys scripts
+livesys-scripts
+
+# libreoffice group
+#@office-suite
+
+# internet-browser group
+firefox
+
+# KDE specific
+@dial-up
+@standard
+
+# install env-group to resolve RhBug:1891500
+@^kde-desktop-environment
+
+@kde-apps
+@kde-media
+
+# drop tracker stuff pulled in by gtk3 (pagureio:fedora-kde/SIG#124)
+-tracker-miners
+-tracker
+
+# Additional packages that are not default in kde-* groups, but useful
+fuse
+
+# EPEL repo
+epel-release
+
+# OpenVPN
+openvpn
+NetworkManager-openvpn
+
+### space issues
+-ktorrent			# kget has also basic torrent features (~3 megs)
+-digikam			# digikam has duplicate functionality with gwenview (~28 megs)
+-kipi-plugins			# ~8 megs + drags in Marble
+-krusader			# ~4 megs
+-k3b				# ~15 megs
+
+# minimization
+-hplip
+
+# Add alsa-sof-firmware to all images PR #51
+alsa-sof-firmware
+# Official NVIDIA GPU Driver Stack
+almalinux-release-nvidia-driver
+
+%end

--- a/kickstarts/10/x86_64/almalinux-live-gnome-nvidia.ks
+++ b/kickstarts/10/x86_64/almalinux-live-gnome-nvidia.ks
@@ -1,0 +1,243 @@
+# AlmaLinux Live Media (Beta - experimental), with optional install option.
+# Build: sudo livecd-creator --cache=~/livecd-creator/package-cache -c almalinux-8-live-gnome.ks -f AlmaLinux-8-Live-gnome
+# X Window System configuration information
+xconfig  --startxonboot
+# Keyboard layouts
+keyboard 'us'
+
+# System timezone
+timezone US/Eastern
+# System language
+lang en_US.UTF-8
+# Firewall configuration
+firewall --enabled --service=mdns
+
+# Repos
+url --url=https://repo.almalinux.org/almalinux/10/BaseOS/$basearch/os/
+repo --name="appstream" --baseurl=https://repo.almalinux.org/almalinux/10/AppStream/$basearch/os/
+repo --name="extras" --baseurl=https://repo.almalinux.org/almalinux/10/extras/$basearch/os/
+repo --name="crb" --baseurl=https://repo.almalinux.org/almalinux/10/CRB/$basearch/os/
+repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10z/Everything/$basearch/
+repo --name="almalinux-nvidia" --baseurl="https://nvidia.repo.almalinux.org/cuda/10/$basearch/"
+
+# Network information
+network --activate --bootproto=dhcp --device=link --onboot=on
+
+# SELinux configuration
+selinux --enforcing
+
+# System services
+services --disabled="sshd" --enabled="NetworkManager,ModemManager"
+
+# livemedia-creator modifications.
+shutdown
+# System bootloader configuration
+bootloader --location=none
+# Clear blank disks or all existing partitions
+clearpart --all --initlabel
+rootpw rootme
+# Disk partitioning information
+part / --size=10238
+
+
+%post --nochroot
+# Back up original resolv.conf in chroot if it exists
+if [ -L $ANA_INSTALL_PATH/etc/resolv.conf ]; then
+    readlink $ANA_INSTALL_PATH/etc/resolv.conf > $ANA_INSTALL_PATH/etc/resolv.conf.orig_link
+    rm -f $ANA_INSTALL_PATH/etc/resolv.conf
+elif [ -f $ANA_INSTALL_PATH/etc/resolv.conf ]; then
+    cp -p $ANA_INSTALL_PATH/etc/resolv.conf $ANA_INSTALL_PATH/etc/resolv.conf.orig
+    rm -f $ANA_INSTALL_PATH/etc/resolv.conf
+else
+    touch $ANA_INSTALL_PATH/etc/resolv.conf.orig_none
+fi
+
+# Copy host DNS configuration to chroot to enable package downloads in %post
+cat /etc/resolv.conf > $ANA_INSTALL_PATH/etc/resolv.conf
+%end
+
+%post
+# Record all running process PIDs at the start of %post to identify background daemons
+INITIAL_PIDS=$(ps -A -o pid=)
+
+# Tell DNF not to use system dbus/user daemons during the live install phase
+export DNF_NO_PLUGINS=1
+
+# Enable livesys services
+systemctl enable livesys.service
+systemctl enable livesys-late.service
+
+# enable tmpfs for /tmp
+systemctl enable tmp.mount
+
+# make it so that we don't do writing to the overlay for things which
+# are just tmpdirs/caches
+# note https://bugzilla.redhat.com/show_bug.cgi?id=1135475
+cat >> /etc/fstab << EOF
+vartmp   /var/tmp    tmpfs   defaults   0  0
+EOF
+
+# work around for poor key import UI in PackageKit
+rm -f /var/lib/rpm/__db*
+# import AlmaLinux PGP key
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
+echo "Packages within this LiveCD"
+rpm -qa
+# Note that running rpm recreates the rpm db files which aren't needed or wanted
+rm -f /var/lib/rpm/__db*
+
+# go ahead and pre-make the man -k cache (#455968)
+/usr/bin/mandb
+
+# make sure there aren't core files lying around
+rm -f /core*
+
+# convince readahead not to collect
+# FIXME: for systemd
+
+echo 'File created by kickstart. See systemd-update-done.service(8).' \
+    | tee /etc/.updated >/var/.updated
+
+# Remove random-seed
+rm /var/lib/systemd/random-seed
+
+# Remove the rescue kernel and image to save space
+# Installation will recreate these on the target
+rm -f /boot/*-rescue*
+
+# Disable network service here, as doing it in the services line
+# fails due to RHBZ #1369794
+systemctl disable network
+
+# Remove machine-id on pre generated images
+rm -f /etc/machine-id
+touch /etc/machine-id
+
+# set livesys session type
+sed -i 's/^livesys_session=.*/livesys_session="gnome"/' /etc/sysconfig/livesys
+
+# Workaround to add openvpn user and group in case they didn't added during
+# openvpn package installation
+getent group openvpn &>/dev/null || groupadd -r openvpn
+getent passwd openvpn &>/dev/null || \
+    /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
+        -d /etc/openvpn openvpn
+
+# TODO: To place Firefox into Task Manager
+# This should be removed when upstream fixes the livesys-scripts package
+sed -i  's/org.mozilla.firefox.desktop/firefox.desktop/g' /usr/libexec/livesys/sessions.d/livesys-gnome
+
+# Install NVIDIA drivers here to avoid %pretrans /bin/sh dependency issue during image build.
+# Install them in %post after the base system is created and /bin/sh exists.
+dnf install -y --enablerepo=almalinux-nvidia --enablerepo=crb nvidia-open libva-nvidia-driver
+
+# Restore original resolv.conf configuration
+if [ -f /etc/resolv.conf.orig_link ]; then
+    ORIG_TARGET=$(cat /etc/resolv.conf.orig_link)
+    rm -f /etc/resolv.conf /etc/resolv.conf.orig_link
+    ln -sf "$ORIG_TARGET" /etc/resolv.conf
+elif [ -f /etc/resolv.conf.orig ]; then
+    mv -f /etc/resolv.conf.orig /etc/resolv.conf
+elif [ -f /etc/resolv.conf.orig_none ]; then
+    rm -f /etc/resolv.conf /etc/resolv.conf.orig_none
+fi
+
+# Regenerate initramfs to include the NVIDIA kernel modules on the Live Media
+/usr/bin/dracut --regenerate-all --force
+
+# Clean up any background processes started during this %post script to prevent unmount failures
+echo "=== Cleaning up background chroot processes ==="
+CURRENT_PIDS=$(ps -A -o pid=)
+for pid in $CURRENT_PIDS; do
+    if [[ "$pid" != "$$" ]] && [[ "$pid" != "$PPID" ]]; then
+        if ! echo "$INITIAL_PIDS" | grep -q -w "$pid"; then
+            if kill -0 "$pid" 2>/dev/null; then
+                echo "Terminating leftover process PID $pid: $(ps -p "$pid" -o args= || echo "$pid")"
+                kill -9 "$pid" 2>/dev/null || true
+            fi
+        fi
+    fi
+done
+echo "==============================================="
+
+%end
+
+# Packages
+%packages
+# Explicitly specified mandatory packages
+kernel
+kernel-modules
+kernel-modules-extra
+
+# The point of a live image is to install
+anaconda
+anaconda-install-env-deps
+anaconda-live
+@anaconda-tools
+# Anaconda has a weak dep on this and we don't want it on livecds, see
+# https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD
+-fcoe-utils
+-sdubby
+
+# Need aajohan-comfortaa-fonts for the SVG rnotes images
+#aajohan-comfortaa-fonts
+
+# Without this, initramfs generation during live image creation fails: #1242586
+dracut-live
+
+# anaconda needs the locales available to run for different locales
+glibc-all-langpacks
+
+# provide the livesys scripts
+livesys-scripts
+
+# Mandatory to build media with livemedia-creator
+memtest86+
+
+# libreoffice group
+#@office-suite
+
+# internet-browser group
+firefox
+
+# Workstation environment group
+@^workstation-product-environment
+
+# GNOME specific
+@gnome-desktop
+#@gnome-apps
+
+# Exclude unwanted packages from @anaconda-tools group
+-gfs2-utils
+-reiserfs-utils
+
+# Workstation specific
+bash-color-prompt
+exfatprogs
+fpaste
+# iptstate
+nss-mdns
+#ntfs-3g
+#ntfsprogs
+policycoreutils-python-utils
+psmisc
+python3-dnf-plugin-system-upgrade
+toolbox
+#unoconv
+uresourced
+whois
+
+# EPEL repo
+epel-release
+
+# OpenVPN
+openvpn
+NetworkManager-openvpn
+NetworkManager-openvpn-gnome
+
+# minimization
+-hplip
+# Official NVIDIA GPU Driver Stack
+almalinux-release-nvidia-driver
+
+%end

--- a/kickstarts/10/x86_64/almalinux-live-kde-nvidia.ks
+++ b/kickstarts/10/x86_64/almalinux-live-kde-nvidia.ks
@@ -1,0 +1,273 @@
+#version=DEVEL
+# X Window System configuration information
+xconfig  --startxonboot
+# Keyboard layouts
+keyboard 'us'
+# Root password
+rootpw --plaintext rootme
+# System language
+lang en_US.UTF-8
+# Shutdown after installation
+shutdown
+# System timezone
+timezone US/Eastern
+# Network information
+network  --bootproto=dhcp --device=link --activate
+
+# Repos
+url --url=https://repo.almalinux.org/almalinux/10/BaseOS/$basearch/os/
+repo --name="appstream" --baseurl=https://repo.almalinux.org/almalinux/10/AppStream/$basearch/os/
+repo --name="extras" --baseurl=https://repo.almalinux.org/almalinux/10/extras/$basearch/os/
+repo --name="crb" --baseurl=https://repo.almalinux.org/almalinux/10/CRB/$basearch/os/
+repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/10z/Everything/$basearch/
+repo --name="almalinux-nvidia" --baseurl="https://nvidia.repo.almalinux.org/cuda/10/$basearch/"
+
+# Firewall configuration
+firewall --enabled --service=mdns
+# SELinux configuration
+selinux --enforcing
+
+# System services
+services --disabled="sshd" --enabled="NetworkManager,ModemManager"
+# System bootloader configuration
+bootloader --location=none
+# Clear the Master Boot Record
+zerombr
+# Partition clearing information
+clearpart --all --initlabel
+# Disk partitioning information
+part / --size=10238
+
+
+%post --nochroot
+# Back up original resolv.conf in chroot if it exists
+if [ -L $ANA_INSTALL_PATH/etc/resolv.conf ]; then
+    readlink $ANA_INSTALL_PATH/etc/resolv.conf > $ANA_INSTALL_PATH/etc/resolv.conf.orig_link
+    rm -f $ANA_INSTALL_PATH/etc/resolv.conf
+elif [ -f $ANA_INSTALL_PATH/etc/resolv.conf ]; then
+    cp -p $ANA_INSTALL_PATH/etc/resolv.conf $ANA_INSTALL_PATH/etc/resolv.conf.orig
+    rm -f $ANA_INSTALL_PATH/etc/resolv.conf
+else
+    touch $ANA_INSTALL_PATH/etc/resolv.conf.orig_none
+fi
+
+# Copy host DNS configuration to chroot to enable package downloads in %post
+cat /etc/resolv.conf > $ANA_INSTALL_PATH/etc/resolv.conf
+%end
+
+%post
+# Record all running process PIDs at the start of %post to identify background daemons
+INITIAL_PIDS=$(ps -A -o pid=)
+
+# Tell DNF not to use system dbus/user daemons during the live install phase
+export DNF_NO_PLUGINS=1
+
+
+# Enable livesys services
+systemctl enable livesys.service
+systemctl enable livesys-late.service
+
+# Enable sddm since EPEL packages it disabled by default
+systemctl enable sddm.service
+
+# enable tmpfs for /tmp
+systemctl enable tmp.mount
+
+# make it so that we don't do writing to the overlay for things which
+# are just tmpdirs/caches
+# note https://bugzilla.redhat.com/show_bug.cgi?id=1135475
+cat >> /etc/fstab << EOF
+vartmp   /var/tmp    tmpfs   defaults   0  0
+EOF
+
+# work around for poor key import UI in PackageKit
+rm -f /var/lib/rpm/__db*
+# import AlmaLinux PGP key
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
+echo "Packages within this LiveCD"
+rpm -qa
+# Note that running rpm recreates the rpm db files which aren't needed or wanted
+rm -f /var/lib/rpm/__db*
+
+# go ahead and pre-make the man -k cache (#455968)
+/usr/bin/mandb
+
+# make sure there aren't core files lying around
+rm -f /core*
+
+# remove random seed, the newly installed instance should make it's own
+rm -f /var/lib/systemd/random-seed
+
+# convince readahead not to collect
+# FIXME: for systemd
+
+echo 'File created by kickstart. See systemd-update-done.service(8).' \
+    | tee /etc/.updated >/var/.updated
+
+# Drop the rescue kernel and initramfs, we don't need them on the live media itself.
+# See bug 1317709
+rm -f /boot/*-rescue*
+
+# Login screen theme and wallpapers
+cat <<'EOF'>/etc/sddm.conf.d/kde_settings.conf
+[Theme]
+Current=breeze
+EOF
+sed -i 's#background=.*$#background=/usr/share/backgrounds/almalinux-day.jpg#g' \
+  /usr/share/sddm/themes/breeze/theme.conf
+
+# TODO: revise I and II once installer icon is on the separate package
+# like Fedora does at https://src.fedoraproject.org/rpms/kf6-breeze-icons/c/728493c525b4e4e7be5caccba41f66e8d816ee38
+
+# I. Fix org.fedoraproject.AnacondaInstaller.svg broken symlinks
+cp -a /usr/share/icons/hicolor/scalable/apps/org.fedoraproject.AnacondaInstaller.svg \
+  /usr/share/icons/hicolor/48x48/apps/
+# II. Replace live installer icon for the application and welcome center
+cp -a /usr/share/icons/hicolor/scalable/apps/org.fedoraproject.AnacondaInstaller.svg \
+  /usr/share/icons/hicolor/48x48/apps/org.almalinux.AnacondaInstaller.svg
+sed -i 's#Icon=.*$#Icon=org.almalinux.AnacondaInstaller#g' \
+  /usr/share/applications/liveinst.desktop
+
+# Show liveinst.desktop on desktop and in menu
+sed -i 's/NoDisplay=true/NoDisplay=false/' /usr/share/applications/liveinst.desktop
+mkdir /home/liveuser/Desktop
+cp -a /usr/share/applications/liveinst.desktop /home/liveuser/Desktop/liveinst.desktop
+chmod +x /home/liveuser/Desktop/liveinst.desktop
+
+# Disable network service here, as doing it in the services line
+# fails due to RHBZ #1369794
+systemctl disable network
+
+# Remove machine-id on pre generated images
+rm -f /etc/machine-id
+touch /etc/machine-id
+
+# set livesys session type
+sed -i 's/^livesys_session=.*/livesys_session="kde"/' /etc/sysconfig/livesys
+
+# enable CRB repo
+dnf config-manager --enable crb
+
+# Workaround to add openvpn user and group in case they didn't added during
+# openvpn package installation
+getent group openvpn &>/dev/null || groupadd -r openvpn
+getent passwd openvpn &>/dev/null || \
+    /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
+        -d /etc/openvpn openvpn
+
+
+# Install NVIDIA drivers here to avoid %pretrans /bin/sh dependency issue during image build.
+# Install them in %post after the base system is created and /bin/sh exists.
+dnf install -y --enablerepo=almalinux-nvidia --enablerepo=crb nvidia-open libva-nvidia-driver
+
+# Restore original resolv.conf configuration
+if [ -f /etc/resolv.conf.orig_link ]; then
+    ORIG_TARGET=$(cat /etc/resolv.conf.orig_link)
+    rm -f /etc/resolv.conf /etc/resolv.conf.orig_link
+    ln -sf "$ORIG_TARGET" /etc/resolv.conf
+elif [ -f /etc/resolv.conf.orig ]; then
+    mv -f /etc/resolv.conf.orig /etc/resolv.conf
+elif [ -f /etc/resolv.conf.orig_none ]; then
+    rm -f /etc/resolv.conf /etc/resolv.conf.orig_none
+fi
+
+# Regenerate initramfs to include the NVIDIA kernel modules on the Live Media
+/usr/bin/dracut --regenerate-all --force
+
+# Clean up any background processes started during this %post script to prevent unmount failures
+echo "=== Cleaning up background chroot processes ==="
+CURRENT_PIDS=$(ps -A -o pid=)
+for pid in $CURRENT_PIDS; do
+    if [[ "$pid" != "$$" ]] && [[ "$pid" != "$PPID" ]]; then
+        if ! echo "$INITIAL_PIDS" | grep -q -w "$pid"; then
+            if kill -0 "$pid" 2>/dev/null; then
+                echo "Terminating leftover process PID $pid: $(ps -p "$pid" -o args= || echo "$pid")"
+                kill -9 "$pid" 2>/dev/null || true
+            fi
+        fi
+    fi
+done
+echo "==============================================="
+
+%end
+
+%packages
+# Explicitly specified mandatory packages
+kernel
+kernel-modules
+kernel-modules-extra
+
+# The point of a live image is to install
+anaconda
+anaconda-install-env-deps
+anaconda-live
+@anaconda-tools
+# Anaconda has a weak dep on this and we don't want it on livecds, see
+# https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD
+-fcoe-utils
+-sdubby
+
+# Need aajohan-comfortaa-fonts for the SVG rnotes images
+#aajohan-comfortaa-fonts
+
+# Plymouth bgrt/spinner instead of text theme
+plymouth-system-theme
+
+# Without this, initramfs generation during live image creation fails: #1242586
+dracut-live
+
+# anaconda needs the locales available to run for different locales
+glibc-all-langpacks
+
+# provide the livesys scripts
+livesys-scripts
+
+# Mandatory to build media with livemedia-creator
+memtest86+
+
+# libreoffice group
+#@office-suite
+
+# internet-browser group
+firefox
+
+# KDE specific
+@dial-up
+@standard
+
+# install env-group to resolve RhBug:1891500
+@^kde-desktop-environment
+
+@kde-apps
+@kde-media
+
+# drop tracker stuff pulled in by gtk3 (pagureio:fedora-kde/SIG#124)
+-tracker-miners
+-tracker
+
+# Additional packages that are not default in kde-* groups, but useful
+fuse
+
+# EPEL repo
+epel-release
+
+# OpenVPN
+openvpn
+NetworkManager-openvpn
+
+### space issues
+-ktorrent			# kget has also basic torrent features (~3 megs)
+-digikam			# digikam has duplicate functionality with gwenview (~28 megs)
+-kipi-plugins			# ~8 megs + drags in Marble
+-krusader			# ~4 megs
+-k3b				# ~15 megs
+
+# minimization
+-hplip
+
+# Add alsa-sof-firmware to all images PR #51
+alsa-sof-firmware
+# Official NVIDIA GPU Driver Stack
+almalinux-release-nvidia-driver
+
+%end

--- a/kickstarts/9/aarch64/almalinux-live-gnome-nvidia.ks
+++ b/kickstarts/9/aarch64/almalinux-live-gnome-nvidia.ks
@@ -1,0 +1,245 @@
+# AlmaLinux Live Media (Beta - experimental), with optional install option.
+# Build: sudo livecd-creator --cache=~/livecd-creator/package-cache -c almalinux-8-live-gnome.ks -f AlmaLinux-8-Live-gnome
+# X Window System configuration information
+xconfig  --startxonboot
+# Keyboard layouts
+keyboard 'us'
+
+# System timezone
+timezone US/Eastern
+# System language
+lang en_US.UTF-8
+# Firewall configuration
+firewall --enabled --service=mdns
+
+# Repos
+url --url=https://atl.mirrors.knownhost.com/almalinux/9/BaseOS/$basearch/os/
+repo --name="appstream" --baseurl=https://atl.mirrors.knownhost.com/almalinux/9/AppStream/$basearch/os/
+repo --name="extras" --baseurl=https://atl.mirrors.knownhost.com/almalinux/9/extras/$basearch/os/
+repo --name="crb" --baseurl=https://atl.mirrors.knownhost.com/almalinux/9/CRB/$basearch/os/
+repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/9/Everything/$basearch/
+repo --name="almalinux-nvidia" --baseurl="https://nvidia.repo.almalinux.org/cuda/9/$basearch/"
+
+# Network information
+network --activate --bootproto=dhcp --device=link --onboot=on
+
+# SELinux configuration
+selinux --enforcing
+
+# System services
+services --disabled="sshd" --enabled="NetworkManager,ModemManager"
+
+# livemedia-creator modifications.
+shutdown
+# System bootloader configuration
+bootloader --location=none
+# Clear blank disks or all existing partitions
+clearpart --all --initlabel
+rootpw rootme
+# Disk partitioning information
+part / --size=10238
+
+
+%post --nochroot
+# Back up original resolv.conf in chroot if it exists
+if [ -L $ANA_INSTALL_PATH/etc/resolv.conf ]; then
+    readlink $ANA_INSTALL_PATH/etc/resolv.conf > $ANA_INSTALL_PATH/etc/resolv.conf.orig_link
+    rm -f $ANA_INSTALL_PATH/etc/resolv.conf
+elif [ -f $ANA_INSTALL_PATH/etc/resolv.conf ]; then
+    cp -p $ANA_INSTALL_PATH/etc/resolv.conf $ANA_INSTALL_PATH/etc/resolv.conf.orig
+    rm -f $ANA_INSTALL_PATH/etc/resolv.conf
+else
+    touch $ANA_INSTALL_PATH/etc/resolv.conf.orig_none
+fi
+
+# Copy host DNS configuration to chroot to enable package downloads in %post
+cat /etc/resolv.conf > $ANA_INSTALL_PATH/etc/resolv.conf
+%end
+
+%post
+# Record all running process PIDs at the start of %post to identify background daemons
+INITIAL_PIDS=$(ps -A -o pid=)
+
+# Tell DNF not to use system dbus/user daemons during the live install phase
+export DNF_NO_PLUGINS=1
+
+# Enable livesys services
+systemctl enable livesys.service
+systemctl enable livesys-late.service
+
+# enable tmpfs for /tmp
+systemctl enable tmp.mount
+
+# make it so that we don't do writing to the overlay for things which
+# are just tmpdirs/caches
+# note https://bugzilla.redhat.com/show_bug.cgi?id=1135475
+cat >> /etc/fstab << EOF
+vartmp   /var/tmp    tmpfs   defaults   0  0
+EOF
+
+# work around for poor key import UI in PackageKit
+rm -f /var/lib/rpm/__db*
+# import AlmaLinux PGP key
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
+echo "Packages within this LiveCD"
+rpm -qa
+# Note that running rpm recreates the rpm db files which aren't needed or wanted
+rm -f /var/lib/rpm/__db*
+
+# go ahead and pre-make the man -k cache (#455968)
+/usr/bin/mandb
+
+# make sure there aren't core files lying around
+rm -f /core*
+
+# convince readahead not to collect
+# FIXME: for systemd
+
+echo 'File created by kickstart. See systemd-update-done.service(8).' \
+    | tee /etc/.updated >/var/.updated
+
+# Remove random-seed
+rm /var/lib/systemd/random-seed
+
+# Remove the rescue kernel and image to save space
+# Installation will recreate these on the target
+rm -f /boot/*-rescue*
+
+# Disable network service here, as doing it in the services line
+# fails due to RHBZ #1369794
+systemctl disable network
+
+# Remove machine-id on pre generated images
+rm -f /etc/machine-id
+touch /etc/machine-id
+
+# set livesys session type
+sed -i 's/^livesys_session=.*/livesys_session="gnome"/' /etc/sysconfig/livesys
+
+# Workaround to add openvpn user and group in case they didn't added during
+# openvpn package installation
+getent group openvpn &>/dev/null || groupadd -r openvpn
+getent passwd openvpn &>/dev/null || \
+    /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
+        -d /etc/openvpn openvpn
+
+
+# Install NVIDIA drivers here to avoid %pretrans /bin/sh dependency issue during image build.
+# Install them in %post after the base system is created and /bin/sh exists.
+dnf install -y --enablerepo=almalinux-nvidia --enablerepo=crb nvidia-open libva-nvidia-driver
+
+# Restore original resolv.conf configuration
+if [ -f /etc/resolv.conf.orig_link ]; then
+    ORIG_TARGET=$(cat /etc/resolv.conf.orig_link)
+    rm -f /etc/resolv.conf /etc/resolv.conf.orig_link
+    ln -sf "$ORIG_TARGET" /etc/resolv.conf
+elif [ -f /etc/resolv.conf.orig ]; then
+    mv -f /etc/resolv.conf.orig /etc/resolv.conf
+elif [ -f /etc/resolv.conf.orig_none ]; then
+    rm -f /etc/resolv.conf /etc/resolv.conf.orig_none
+fi
+
+# Regenerate initramfs to include the NVIDIA kernel modules on the Live Media
+/usr/bin/dracut --regenerate-all --force
+
+# Clean up any background processes started during this %post script to prevent unmount failures
+echo "=== Cleaning up background chroot processes ==="
+CURRENT_PIDS=$(ps -A -o pid=)
+for pid in $CURRENT_PIDS; do
+    if [[ "$pid" != "$$" ]] && [[ "$pid" != "$PPID" ]]; then
+        if ! echo "$INITIAL_PIDS" | grep -q -w "$pid"; then
+            if kill -0 "$pid" 2>/dev/null; then
+                echo "Terminating leftover process PID $pid: $(ps -p "$pid" -o args= || echo "$pid")"
+                kill -9 "$pid" 2>/dev/null || true
+            fi
+        fi
+    fi
+done
+echo "==============================================="
+
+%end
+
+# Packages
+%packages
+# Explicitly specified mandatory packages
+kernel
+kernel-modules
+kernel-modules-extra
+
+# The point of a live image is to install
+anaconda
+anaconda-install-env-deps
+anaconda-live
+@anaconda-tools
+# Anaconda has a weak dep on this and we don't want it on livecds, see
+# https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD
+-fcoe-utils
+-sdubby
+
+# Need aajohan-comfortaa-fonts for the SVG rnotes images
+aajohan-comfortaa-fonts
+
+# Without this, initramfs generation during live image creation fails: #1242586
+dracut-live
+
+# anaconda needs the locales available to run for different locales
+glibc-all-langpacks
+
+# provide the livesys scripts
+livesys-scripts
+
+# firefox
+@internet-browser
+
+# Workstation environment group (mandatory)
+@core
+@gnome-desktop
+@standard
+@base-x
+@fonts
+@guest-desktop-agents
+@hardware-support
+@multimedia
+@networkmanager-submodules
+@print-client
+
+# Workstation environment group (optional)
+@backup-client
+@headless-management
+@internet-applications
+@remote-desktop-clients
+@smart-card
+
+# Exclude unwanted packages from @anaconda-tools group
+-gfs2-utils
+-reiserfs-utils
+
+# Workstation specific
+bash-color-prompt
+exfatprogs
+fpaste
+iptstate
+nss-mdns
+ntfs-3g
+ntfsprogs
+policycoreutils-python-utils
+psmisc
+python3-dnf-plugin-system-upgrade
+toolbox
+uresourced
+whois
+
+# EPEL repo
+epel-release
+
+# OpenVPN
+openvpn
+NetworkManager-openvpn
+NetworkManager-openvpn-gnome
+
+# minimization
+-hplip
+# Official NVIDIA GPU Driver Stack
+almalinux-release-nvidia-driver
+
+%end

--- a/kickstarts/9/aarch64/almalinux-live-kde-nvidia.ks
+++ b/kickstarts/9/aarch64/almalinux-live-kde-nvidia.ks
@@ -1,0 +1,320 @@
+#version=DEVEL
+# X Window System configuration information
+xconfig  --startxonboot
+# Keyboard layouts
+keyboard 'us'
+# Root password
+rootpw --plaintext rootme
+# System language
+lang en_US.UTF-8
+# Shutdown after installation
+shutdown
+# System timezone
+timezone US/Eastern
+# Network information
+network  --bootproto=dhcp --device=link --activate
+
+# Repos
+url --url=https://atl.mirrors.knownhost.com/almalinux/9/BaseOS/$basearch/os/
+repo --name="appstream" --baseurl=https://atl.mirrors.knownhost.com/almalinux/9/AppStream/$basearch/os/
+repo --name="extras" --baseurl=https://atl.mirrors.knownhost.com/almalinux/9/extras/$basearch/os/
+repo --name="crb" --baseurl=https://atl.mirrors.knownhost.com/almalinux/9/CRB/$basearch/os/
+repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/9/Everything/$basearch/
+repo --name="almalinux-nvidia" --baseurl="https://nvidia.repo.almalinux.org/cuda/9/$basearch/"
+
+# Firewall configuration
+firewall --enabled --service=mdns
+# SELinux configuration
+selinux --enforcing
+
+# System services
+services --disabled="sshd" --enabled="NetworkManager,ModemManager"
+# System bootloader configuration
+bootloader --location=none
+# Clear the Master Boot Record
+zerombr
+# Partition clearing information
+clearpart --all --initlabel
+# Disk partitioning information
+part / --size=10238
+
+
+%post --nochroot
+# Back up original resolv.conf in chroot if it exists
+if [ -L $ANA_INSTALL_PATH/etc/resolv.conf ]; then
+    readlink $ANA_INSTALL_PATH/etc/resolv.conf > $ANA_INSTALL_PATH/etc/resolv.conf.orig_link
+    rm -f $ANA_INSTALL_PATH/etc/resolv.conf
+elif [ -f $ANA_INSTALL_PATH/etc/resolv.conf ]; then
+    cp -p $ANA_INSTALL_PATH/etc/resolv.conf $ANA_INSTALL_PATH/etc/resolv.conf.orig
+    rm -f $ANA_INSTALL_PATH/etc/resolv.conf
+else
+    touch $ANA_INSTALL_PATH/etc/resolv.conf.orig_none
+fi
+
+# Copy host DNS configuration to chroot to enable package downloads in %post
+cat /etc/resolv.conf > $ANA_INSTALL_PATH/etc/resolv.conf
+%end
+
+%post
+# Record all running process PIDs at the start of %post to identify background daemons
+INITIAL_PIDS=$(ps -A -o pid=)
+
+# Tell DNF not to use system dbus/user daemons during the live install phase
+export DNF_NO_PLUGINS=1
+
+
+# Enable livesys services
+systemctl enable livesys.service
+systemctl enable livesys-late.service
+
+# Enable sddm since EPEL packages it disabled by default
+systemctl enable sddm.service
+
+# enable tmpfs for /tmp
+systemctl enable tmp.mount
+
+# make it so that we don't do writing to the overlay for things which
+# are just tmpdirs/caches
+# note https://bugzilla.redhat.com/show_bug.cgi?id=1135475
+cat >> /etc/fstab << EOF
+vartmp   /var/tmp    tmpfs   defaults   0  0
+EOF
+
+# work around for poor key import UI in PackageKit
+rm -f /var/lib/rpm/__db*
+# import AlmaLinux PGP key
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
+echo "Packages within this LiveCD"
+rpm -qa
+# Note that running rpm recreates the rpm db files which aren't needed or wanted
+rm -f /var/lib/rpm/__db*
+
+# go ahead and pre-make the man -k cache (#455968)
+/usr/bin/mandb
+
+# make sure there aren't core files lying around
+rm -f /core*
+
+# remove random seed, the newly installed instance should make it's own
+rm -f /var/lib/systemd/random-seed
+
+# convince readahead not to collect
+# FIXME: for systemd
+
+echo 'File created by kickstart. See systemd-update-done.service(8).' \
+    | tee /etc/.updated >/var/.updated
+
+# Drop the rescue kernel and initramfs, we don't need them on the live media itself.
+# See bug 1317709
+rm -f /boot/*-rescue*
+
+# TODO: almalinux-backgrounds-extras package looks good, remove inline method
+# on next build
+generateKDEWallpapers() {
+  # Declare an array for background types
+  declare -a bgtypes=("dark" "light" "abstract-dark" "abstract-light" "mountains-dark" "mountains-white" "waves-dark" "waves-light" "waves-sunset")
+  # Declare an array for background sizes
+  declare -a sizes=("1800x1440.jpg" "2048x1536.jpg" "2560x1080.jpg" "2560x1440.jpg" "2560x1600.jpg" "3440x1440.jpg")
+  ## Loop through the above array(s) types and sizes to create links and metadata
+  for bg in "${bgtypes[@]}"
+  do
+    echo "Processing 'Alma-"$bg"' background"
+    # Remove any old folders and create new structure
+    rm -rf /usr/share/wallpapers/Alma-$bg*
+    mkdir -p /usr/share/wallpapers/Alma-$bg/contents/images/
+    # creae sym link for all sizes
+    for size in "${sizes[@]}"
+    do
+    ln -s /usr/share/backgrounds/Alma-$bg-$size /usr/share/wallpapers/Alma-$bg/contents/images/$size
+    done
+    # Create metadata file to make Desktop Wallpaper application happy
+    # Move this to pre-created files in repo to give support to other languages
+    # This is quick hack for time being.
+    cat > /usr/share/wallpapers/Alma-$bg/metadata.desktop <<FOE
+[Desktop Entry]
+Name=AlmaLinux $bg
+
+X-KDE-PluginInfo-Author=Bala Raman
+X-KDE-PluginInfo-Email=srbala@gmail.com
+X-KDE-PluginInfo-Name=Alma-$bg
+X-KDE-PluginInfo-Version=0.1.0
+X-KDE-PluginInfo-Website=https://almalinux.org
+X-KDE-PluginInfo-Category=
+X-KDE-PluginInfo-Depends=
+X-KDE-PluginInfo-License=CC-BY-SA
+X-KDE-PluginInfo-EnabledByDefault=true
+X-Plasma-API=5.0
+
+FOE
+  done
+}
+# call function to create wallpapers
+# generateKDEWallpapers
+# Very ODD fix to get Alma background, find alternative
+rm -rf /usr/share/wallpapers/Fedora
+ln -s Alma-mountains-white /usr/share/wallpapers/Fedora
+# background end
+
+# Update default theme - this has to stay KS
+# Hack KDE Fedora package starts. TODO: need almalinux-kde-fix package
+sed -i 's/defaultWallpaperTheme=Fedora/defaultWallpaperTheme=Alma-mountains-white/' /usr/share/plasma/desktoptheme/default/metadata.desktop
+sed -i 's/defaultFileSuffix=.png/defaultFileSuffix=.jpg/' /usr/share/plasma/desktoptheme/default/metadata.desktop
+sed -i 's/defaultWidth=1920/defaultWidth=2048/' /usr/share/plasma/desktoptheme/default/metadata.desktop
+sed -i 's/defaultHeight=1080/defaultHeight=1536/' /usr/share/plasma/desktoptheme/default/metadata.desktop
+# Update KInfocenter
+sed -i 's/pixmaps\/system-logo-white.png/icons\/hicolor\/256x256\/apps\/fedora-logo-icon.png/' /etc/xdg/kcm-about-distrorc
+sed -i 's/http:\/\/fedoraproject.org/https:\/\/almalinux.org/' /etc/xdg/kcm-about-distrorc
+# Hack KDE Fedora package ends
+
+# Disable network service here, as doing it in the services line
+# fails due to RHBZ #1369794
+systemctl disable network
+
+# Remove machine-id on pre generated images
+rm -f /etc/machine-id
+touch /etc/machine-id
+
+# set livesys session type
+sed -i 's/^livesys_session=.*/livesys_session="kde"/' /etc/sysconfig/livesys
+
+# set default GTK+ theme for root (see #683855, #689070, #808062)
+cat > /root/.gtkrc-2.0 << EOF
+include "/usr/share/themes/Adwaita/gtk-2.0/gtkrc"
+include "/etc/gtk-2.0/gtkrc"
+gtk-theme-name="Adwaita"
+EOF
+mkdir -p /root/.config/gtk-3.0
+cat > /root/.config/gtk-3.0/settings.ini << EOF
+[Settings]
+gtk-theme-name = Adwaita
+EOF
+
+# enable CRB repo
+dnf config-manager --enable crb
+
+# Workaround to add openvpn user and group in case they didn't added during
+# openvpn package installation
+getent group openvpn &>/dev/null || groupadd -r openvpn
+getent passwd openvpn &>/dev/null || \
+    /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
+        -d /etc/openvpn openvpn
+
+
+# Install NVIDIA drivers here to avoid %pretrans /bin/sh dependency issue during image build.
+# Install them in %post after the base system is created and /bin/sh exists.
+dnf install -y --enablerepo=almalinux-nvidia --enablerepo=crb nvidia-open libva-nvidia-driver
+
+# Restore original resolv.conf configuration
+if [ -f /etc/resolv.conf.orig_link ]; then
+    ORIG_TARGET=$(cat /etc/resolv.conf.orig_link)
+    rm -f /etc/resolv.conf /etc/resolv.conf.orig_link
+    ln -sf "$ORIG_TARGET" /etc/resolv.conf
+elif [ -f /etc/resolv.conf.orig ]; then
+    mv -f /etc/resolv.conf.orig /etc/resolv.conf
+elif [ -f /etc/resolv.conf.orig_none ]; then
+    rm -f /etc/resolv.conf /etc/resolv.conf.orig_none
+fi
+
+# Regenerate initramfs to include the NVIDIA kernel modules on the Live Media
+/usr/bin/dracut --regenerate-all --force
+
+# Clean up any background processes started during this %post script to prevent unmount failures
+echo "=== Cleaning up background chroot processes ==="
+CURRENT_PIDS=$(ps -A -o pid=)
+for pid in $CURRENT_PIDS; do
+    if [[ "$pid" != "$$" ]] && [[ "$pid" != "$PPID" ]]; then
+        if ! echo "$INITIAL_PIDS" | grep -q -w "$pid"; then
+            if kill -0 "$pid" 2>/dev/null; then
+                echo "Terminating leftover process PID $pid: $(ps -p "$pid" -o args= || echo "$pid")"
+                kill -9 "$pid" 2>/dev/null || true
+            fi
+        fi
+    fi
+done
+echo "==============================================="
+
+%end
+
+%post --nochroot
+# cp $INSTALL_ROOT/usr/share/licenses/*-release/* $LIVE_ROOT/
+
+# only works on x86, x86_64
+if [ "$(uname -m)" = "i386" -o "$(uname -m)" = "x86_64" ]; then
+  if [ ! -d $LIVE_ROOT/LiveOS ]; then mkdir -p $LIVE_ROOT/LiveOS ; fi
+  cp /usr/bin/livecd-iso-to-disk $LIVE_ROOT/LiveOS
+fi
+
+%end
+
+%packages
+# Explicitly specified mandatory packages
+kernel
+kernel-modules
+kernel-modules-extra
+
+# The point of a live image is to install
+anaconda
+anaconda-install-env-deps
+anaconda-live
+@anaconda-tools
+# Anaconda has a weak dep on this and we don't want it on livecds, see
+# https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD
+-fcoe-utils
+-sdubby
+
+# Need aajohan-comfortaa-fonts for the SVG rnotes images
+aajohan-comfortaa-fonts
+
+# Without this, initramfs generation during live image creation fails: #1242586
+dracut-live
+
+# anaconda needs the locales available to run for different locales
+glibc-all-langpacks
+
+# provide the livesys scripts
+livesys-scripts
+
+# libreoffice group
+@office-suite
+# firefox
+@internet-browser
+
+# KDE specific
+@dial-up
+@standard
+
+# install env-group to resolve RhBug:1891500
+@^kde-desktop-environment
+-kde-connect
+-kdeconnectd
+-kde-connect-libs
+
+@kde-apps
+@kde-media
+
+# drop tracker stuff pulled in by gtk3 (pagureio:fedora-kde/SIG#124)
+-tracker-miners
+-tracker
+
+# Additional packages that are not default in kde-* groups, but useful
+fuse
+
+# EPEL repo
+epel-release
+
+### space issues
+-ktorrent			# kget has also basic torrent features (~3 megs)
+-digikam			# digikam has duplicate functionality with gwenview (~28 megs)
+-kipi-plugins			# ~8 megs + drags in Marble
+-krusader			# ~4 megs
+-k3b				# ~15 megs
+
+# minimization
+-hplip
+
+# Add alsa-sof-firmware to all images PR #51
+alsa-sof-firmware
+# Official NVIDIA GPU Driver Stack
+almalinux-release-nvidia-driver
+
+%end

--- a/kickstarts/9/x86_64/almalinux-live-gnome-nvidia.ks
+++ b/kickstarts/9/x86_64/almalinux-live-gnome-nvidia.ks
@@ -1,0 +1,239 @@
+# AlmaLinux Live Media (Beta - experimental), with optional install option.
+# Build: sudo livecd-creator --cache=~/livecd-creator/package-cache -c almalinux-8-live-gnome.ks -f AlmaLinux-8-Live-gnome
+# X Window System configuration information
+xconfig  --startxonboot
+# Keyboard layouts
+keyboard 'us'
+
+# System timezone
+timezone US/Eastern
+# System language
+lang en_US.UTF-8
+# Firewall configuration
+firewall --enabled --service=mdns
+
+# Repos
+url --url=https://atl.mirrors.knownhost.com/almalinux/9/BaseOS/$basearch/os/
+repo --name="appstream" --baseurl=https://atl.mirrors.knownhost.com/almalinux/9/AppStream/$basearch/os/
+repo --name="extras" --baseurl=https://atl.mirrors.knownhost.com/almalinux/9/extras/$basearch/os/
+repo --name="crb" --baseurl=https://atl.mirrors.knownhost.com/almalinux/9/CRB/$basearch/os/
+repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/9/Everything/$basearch/
+repo --name="almalinux-nvidia" --baseurl="https://nvidia.repo.almalinux.org/cuda/9/$basearch/"
+
+# Network information
+network --activate --bootproto=dhcp --device=link --onboot=on
+
+# SELinux configuration
+selinux --enforcing
+
+# System services
+services --disabled="sshd" --enabled="NetworkManager,ModemManager"
+
+# livemedia-creator modifications.
+shutdown
+# System bootloader configuration
+bootloader --location=none
+# Clear blank disks or all existing partitions
+clearpart --all --initlabel
+rootpw rootme
+# Disk partitioning information
+part / --size=10238
+
+
+%post --nochroot
+# Back up original resolv.conf in chroot if it exists
+if [ -L $ANA_INSTALL_PATH/etc/resolv.conf ]; then
+    readlink $ANA_INSTALL_PATH/etc/resolv.conf > $ANA_INSTALL_PATH/etc/resolv.conf.orig_link
+    rm -f $ANA_INSTALL_PATH/etc/resolv.conf
+elif [ -f $ANA_INSTALL_PATH/etc/resolv.conf ]; then
+    cp -p $ANA_INSTALL_PATH/etc/resolv.conf $ANA_INSTALL_PATH/etc/resolv.conf.orig
+    rm -f $ANA_INSTALL_PATH/etc/resolv.conf
+else
+    touch $ANA_INSTALL_PATH/etc/resolv.conf.orig_none
+fi
+
+# Copy host DNS configuration to chroot to enable package downloads in %post
+cat /etc/resolv.conf > $ANA_INSTALL_PATH/etc/resolv.conf
+%end
+
+%post
+# Record all running process PIDs at the start of %post to identify background daemons
+INITIAL_PIDS=$(ps -A -o pid=)
+
+# Tell DNF not to use system dbus/user daemons during the live install phase
+export DNF_NO_PLUGINS=1
+
+# Enable livesys services
+systemctl enable livesys.service
+systemctl enable livesys-late.service
+
+# enable tmpfs for /tmp
+systemctl enable tmp.mount
+
+# make it so that we don't do writing to the overlay for things which
+# are just tmpdirs/caches
+# note https://bugzilla.redhat.com/show_bug.cgi?id=1135475
+cat >> /etc/fstab << EOF
+vartmp   /var/tmp    tmpfs   defaults   0  0
+EOF
+
+# work around for poor key import UI in PackageKit
+rm -f /var/lib/rpm/__db*
+# import AlmaLinux PGP key
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
+echo "Packages within this LiveCD"
+rpm -qa
+# Note that running rpm recreates the rpm db files which aren't needed or wanted
+rm -f /var/lib/rpm/__db*
+
+# go ahead and pre-make the man -k cache (#455968)
+/usr/bin/mandb
+
+# make sure there aren't core files lying around
+rm -f /core*
+
+# convince readahead not to collect
+# FIXME: for systemd
+
+echo 'File created by kickstart. See systemd-update-done.service(8).' \
+    | tee /etc/.updated >/var/.updated
+
+# Remove random-seed
+rm /var/lib/systemd/random-seed
+
+# Remove the rescue kernel and image to save space
+# Installation will recreate these on the target
+rm -f /boot/*-rescue*
+
+# Disable network service here, as doing it in the services line
+# fails due to RHBZ #1369794
+systemctl disable network
+
+# Remove machine-id on pre generated images
+rm -f /etc/machine-id
+touch /etc/machine-id
+
+# set livesys session type
+sed -i 's/^livesys_session=.*/livesys_session="gnome"/' /etc/sysconfig/livesys
+
+# Workaround to add openvpn user and group in case they didn't added during
+# openvpn package installation
+getent group openvpn &>/dev/null || groupadd -r openvpn
+getent passwd openvpn &>/dev/null || \
+    /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
+        -d /etc/openvpn openvpn
+
+
+# Install NVIDIA drivers here to avoid %pretrans /bin/sh dependency issue during image build.
+# Install them in %post after the base system is created and /bin/sh exists.
+dnf install -y --enablerepo=almalinux-nvidia --enablerepo=crb nvidia-open libva-nvidia-driver
+
+# Restore original resolv.conf configuration
+if [ -f /etc/resolv.conf.orig_link ]; then
+    ORIG_TARGET=$(cat /etc/resolv.conf.orig_link)
+    rm -f /etc/resolv.conf /etc/resolv.conf.orig_link
+    ln -sf "$ORIG_TARGET" /etc/resolv.conf
+elif [ -f /etc/resolv.conf.orig ]; then
+    mv -f /etc/resolv.conf.orig /etc/resolv.conf
+elif [ -f /etc/resolv.conf.orig_none ]; then
+    rm -f /etc/resolv.conf /etc/resolv.conf.orig_none
+fi
+
+# Regenerate initramfs to include the NVIDIA kernel modules on the Live Media
+/usr/bin/dracut --regenerate-all --force
+
+# Clean up any background processes started during this %post script to prevent unmount failures
+echo "=== Cleaning up background chroot processes ==="
+CURRENT_PIDS=$(ps -A -o pid=)
+for pid in $CURRENT_PIDS; do
+    if [[ "$pid" != "$$" ]] && [[ "$pid" != "$PPID" ]]; then
+        if ! echo "$INITIAL_PIDS" | grep -q -w "$pid"; then
+            if kill -0 "$pid" 2>/dev/null; then
+                echo "Terminating leftover process PID $pid: $(ps -p "$pid" -o args= || echo "$pid")"
+                kill -9 "$pid" 2>/dev/null || true
+            fi
+        fi
+    fi
+done
+echo "==============================================="
+
+%end
+
+# Packages
+%packages
+# Explicitly specified mandatory packages
+kernel
+kernel-modules
+kernel-modules-extra
+
+# The point of a live image is to install
+anaconda
+anaconda-install-env-deps
+anaconda-live
+@anaconda-tools
+# Anaconda has a weak dep on this and we don't want it on livecds, see
+# https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD
+-fcoe-utils
+-sdubby
+
+# Need aajohan-comfortaa-fonts for the SVG rnotes images
+aajohan-comfortaa-fonts
+
+# Without this, initramfs generation during live image creation fails: #1242586
+dracut-live
+
+# anaconda needs the locales available to run for different locales
+glibc-all-langpacks
+
+# provide the livesys scripts
+livesys-scripts
+
+# Mandatory to build media with livemedia-creator
+memtest86+
+
+# libreoffice group
+@office-suite
+
+# firefox
+@internet-browser
+
+# Workstation environment group
+@^workstation-product-environment
+
+# GNOME specific
+@gnome-apps
+
+# Exclude unwanted packages from @anaconda-tools group
+-gfs2-utils
+-reiserfs-utils
+
+# Workstation specific
+bash-color-prompt
+exfatprogs
+fpaste
+iptstate
+nss-mdns
+ntfs-3g
+ntfsprogs
+policycoreutils-python-utils
+psmisc
+python3-dnf-plugin-system-upgrade
+toolbox
+unoconv
+uresourced
+whois
+
+# EPEL repo
+epel-release
+
+# OpenVPN
+openvpn
+NetworkManager-openvpn
+NetworkManager-openvpn-gnome
+
+# minimization
+-hplip
+# Official NVIDIA GPU Driver Stack
+almalinux-release-nvidia-driver
+
+%end

--- a/kickstarts/9/x86_64/almalinux-live-kde-nvidia.ks
+++ b/kickstarts/9/x86_64/almalinux-live-kde-nvidia.ks
@@ -1,0 +1,323 @@
+#version=DEVEL
+# X Window System configuration information
+xconfig  --startxonboot
+# Keyboard layouts
+keyboard 'us'
+# Root password
+rootpw --plaintext rootme
+# System language
+lang en_US.UTF-8
+# Shutdown after installation
+shutdown
+# System timezone
+timezone US/Eastern
+# Network information
+network  --bootproto=dhcp --device=link --activate
+
+# Repos
+url --url=https://atl.mirrors.knownhost.com/almalinux/9/BaseOS/$basearch/os/
+repo --name="appstream" --baseurl=https://atl.mirrors.knownhost.com/almalinux/9/AppStream/$basearch/os/
+repo --name="extras" --baseurl=https://atl.mirrors.knownhost.com/almalinux/9/extras/$basearch/os/
+repo --name="crb" --baseurl=https://atl.mirrors.knownhost.com/almalinux/9/CRB/$basearch/os/
+repo --name="epel" --baseurl=https://dl.fedoraproject.org/pub/epel/9/Everything/$basearch/
+repo --name="almalinux-nvidia" --baseurl="https://nvidia.repo.almalinux.org/cuda/9/$basearch/"
+
+# Firewall configuration
+firewall --enabled --service=mdns
+# SELinux configuration
+selinux --enforcing
+
+# System services
+services --disabled="sshd" --enabled="NetworkManager,ModemManager"
+# System bootloader configuration
+bootloader --location=none
+# Clear the Master Boot Record
+zerombr
+# Partition clearing information
+clearpart --all --initlabel
+# Disk partitioning information
+part / --size=10238
+
+
+%post --nochroot
+# Back up original resolv.conf in chroot if it exists
+if [ -L $ANA_INSTALL_PATH/etc/resolv.conf ]; then
+    readlink $ANA_INSTALL_PATH/etc/resolv.conf > $ANA_INSTALL_PATH/etc/resolv.conf.orig_link
+    rm -f $ANA_INSTALL_PATH/etc/resolv.conf
+elif [ -f $ANA_INSTALL_PATH/etc/resolv.conf ]; then
+    cp -p $ANA_INSTALL_PATH/etc/resolv.conf $ANA_INSTALL_PATH/etc/resolv.conf.orig
+    rm -f $ANA_INSTALL_PATH/etc/resolv.conf
+else
+    touch $ANA_INSTALL_PATH/etc/resolv.conf.orig_none
+fi
+
+# Copy host DNS configuration to chroot to enable package downloads in %post
+cat /etc/resolv.conf > $ANA_INSTALL_PATH/etc/resolv.conf
+%end
+
+%post
+# Record all running process PIDs at the start of %post to identify background daemons
+INITIAL_PIDS=$(ps -A -o pid=)
+
+# Tell DNF not to use system dbus/user daemons during the live install phase
+export DNF_NO_PLUGINS=1
+
+
+# Enable livesys services
+systemctl enable livesys.service
+systemctl enable livesys-late.service
+
+# Enable sddm since EPEL packages it disabled by default
+systemctl enable sddm.service
+
+# enable tmpfs for /tmp
+systemctl enable tmp.mount
+
+# make it so that we don't do writing to the overlay for things which
+# are just tmpdirs/caches
+# note https://bugzilla.redhat.com/show_bug.cgi?id=1135475
+cat >> /etc/fstab << EOF
+vartmp   /var/tmp    tmpfs   defaults   0  0
+EOF
+
+# work around for poor key import UI in PackageKit
+rm -f /var/lib/rpm/__db*
+# import AlmaLinux PGP key
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
+echo "Packages within this LiveCD"
+rpm -qa
+# Note that running rpm recreates the rpm db files which aren't needed or wanted
+rm -f /var/lib/rpm/__db*
+
+# go ahead and pre-make the man -k cache (#455968)
+/usr/bin/mandb
+
+# make sure there aren't core files lying around
+rm -f /core*
+
+# remove random seed, the newly installed instance should make it's own
+rm -f /var/lib/systemd/random-seed
+
+# convince readahead not to collect
+# FIXME: for systemd
+
+echo 'File created by kickstart. See systemd-update-done.service(8).' \
+    | tee /etc/.updated >/var/.updated
+
+# Drop the rescue kernel and initramfs, we don't need them on the live media itself.
+# See bug 1317709
+rm -f /boot/*-rescue*
+
+# TODO: almalinux-backgrounds-extras package looks good, remove inline method
+# on next build
+generateKDEWallpapers() {
+  # Declare an array for background types
+  declare -a bgtypes=("dark" "light" "abstract-dark" "abstract-light" "mountains-dark" "mountains-white" "waves-dark" "waves-light" "waves-sunset")
+  # Declare an array for background sizes
+  declare -a sizes=("1800x1440.jpg" "2048x1536.jpg" "2560x1080.jpg" "2560x1440.jpg" "2560x1600.jpg" "3440x1440.jpg")
+  ## Loop through the above array(s) types and sizes to create links and metadata
+  for bg in "${bgtypes[@]}"
+  do
+    echo "Processing 'Alma-"$bg"' background"
+    # Remove any old folders and create new structure
+    rm -rf /usr/share/wallpapers/Alma-$bg*
+    mkdir -p /usr/share/wallpapers/Alma-$bg/contents/images/
+    # creae sym link for all sizes
+    for size in "${sizes[@]}"
+    do
+    ln -s /usr/share/backgrounds/Alma-$bg-$size /usr/share/wallpapers/Alma-$bg/contents/images/$size
+    done
+    # Create metadata file to make Desktop Wallpaper application happy
+    # Move this to pre-created files in repo to give support to other languages
+    # This is quick hack for time being.
+    cat > /usr/share/wallpapers/Alma-$bg/metadata.desktop <<FOE
+[Desktop Entry]
+Name=AlmaLinux $bg
+
+X-KDE-PluginInfo-Author=Bala Raman
+X-KDE-PluginInfo-Email=srbala@gmail.com
+X-KDE-PluginInfo-Name=Alma-$bg
+X-KDE-PluginInfo-Version=0.1.0
+X-KDE-PluginInfo-Website=https://almalinux.org
+X-KDE-PluginInfo-Category=
+X-KDE-PluginInfo-Depends=
+X-KDE-PluginInfo-License=CC-BY-SA
+X-KDE-PluginInfo-EnabledByDefault=true
+X-Plasma-API=5.0
+
+FOE
+  done
+}
+# call function to create wallpapers
+# generateKDEWallpapers
+# Very ODD fix to get Alma background, find alternative
+rm -rf /usr/share/wallpapers/Fedora
+ln -s Alma-mountains-white /usr/share/wallpapers/Fedora
+# background end
+
+# Update default theme - this has to stay KS
+# Hack KDE Fedora package starts. TODO: need almalinux-kde-fix package
+sed -i 's/defaultWallpaperTheme=Fedora/defaultWallpaperTheme=Alma-mountains-white/' /usr/share/plasma/desktoptheme/default/metadata.desktop
+sed -i 's/defaultFileSuffix=.png/defaultFileSuffix=.jpg/' /usr/share/plasma/desktoptheme/default/metadata.desktop
+sed -i 's/defaultWidth=1920/defaultWidth=2048/' /usr/share/plasma/desktoptheme/default/metadata.desktop
+sed -i 's/defaultHeight=1080/defaultHeight=1536/' /usr/share/plasma/desktoptheme/default/metadata.desktop
+# Update KInfocenter
+sed -i 's/pixmaps\/system-logo-white.png/icons\/hicolor\/256x256\/apps\/fedora-logo-icon.png/' /etc/xdg/kcm-about-distrorc
+sed -i 's/http:\/\/fedoraproject.org/https:\/\/almalinux.org/' /etc/xdg/kcm-about-distrorc
+# Hack KDE Fedora package ends
+
+# Disable network service here, as doing it in the services line
+# fails due to RHBZ #1369794
+systemctl disable network
+
+# Remove machine-id on pre generated images
+rm -f /etc/machine-id
+touch /etc/machine-id
+
+# set livesys session type
+sed -i 's/^livesys_session=.*/livesys_session="kde"/' /etc/sysconfig/livesys
+
+# set default GTK+ theme for root (see #683855, #689070, #808062)
+cat > /root/.gtkrc-2.0 << EOF
+include "/usr/share/themes/Adwaita/gtk-2.0/gtkrc"
+include "/etc/gtk-2.0/gtkrc"
+gtk-theme-name="Adwaita"
+EOF
+mkdir -p /root/.config/gtk-3.0
+cat > /root/.config/gtk-3.0/settings.ini << EOF
+[Settings]
+gtk-theme-name = Adwaita
+EOF
+
+# enable CRB repo
+dnf config-manager --enable crb
+
+# Workaround to add openvpn user and group in case they didn't added during
+# openvpn package installation
+getent group openvpn &>/dev/null || groupadd -r openvpn
+getent passwd openvpn &>/dev/null || \
+    /usr/sbin/useradd -r -g openvpn -s /sbin/nologin -c OpenVPN \
+        -d /etc/openvpn openvpn
+
+
+# Install NVIDIA drivers here to avoid %pretrans /bin/sh dependency issue during image build.
+# Install them in %post after the base system is created and /bin/sh exists.
+dnf install -y --enablerepo=almalinux-nvidia --enablerepo=crb nvidia-open libva-nvidia-driver
+
+# Restore original resolv.conf configuration
+if [ -f /etc/resolv.conf.orig_link ]; then
+    ORIG_TARGET=$(cat /etc/resolv.conf.orig_link)
+    rm -f /etc/resolv.conf /etc/resolv.conf.orig_link
+    ln -sf "$ORIG_TARGET" /etc/resolv.conf
+elif [ -f /etc/resolv.conf.orig ]; then
+    mv -f /etc/resolv.conf.orig /etc/resolv.conf
+elif [ -f /etc/resolv.conf.orig_none ]; then
+    rm -f /etc/resolv.conf /etc/resolv.conf.orig_none
+fi
+
+# Regenerate initramfs to include the NVIDIA kernel modules on the Live Media
+/usr/bin/dracut --regenerate-all --force
+
+# Clean up any background processes started during this %post script to prevent unmount failures
+echo "=== Cleaning up background chroot processes ==="
+CURRENT_PIDS=$(ps -A -o pid=)
+for pid in $CURRENT_PIDS; do
+    if [[ "$pid" != "$$" ]] && [[ "$pid" != "$PPID" ]]; then
+        if ! echo "$INITIAL_PIDS" | grep -q -w "$pid"; then
+            if kill -0 "$pid" 2>/dev/null; then
+                echo "Terminating leftover process PID $pid: $(ps -p "$pid" -o args= || echo "$pid")"
+                kill -9 "$pid" 2>/dev/null || true
+            fi
+        fi
+    fi
+done
+echo "==============================================="
+
+%end
+
+%post --nochroot
+# cp $INSTALL_ROOT/usr/share/licenses/*-release/* $LIVE_ROOT/
+
+# only works on x86, x86_64
+if [ "$(uname -m)" = "i386" -o "$(uname -m)" = "x86_64" ]; then
+  if [ ! -d $LIVE_ROOT/LiveOS ]; then mkdir -p $LIVE_ROOT/LiveOS ; fi
+  cp /usr/bin/livecd-iso-to-disk $LIVE_ROOT/LiveOS
+fi
+
+%end
+
+%packages
+# Explicitly specified mandatory packages
+kernel
+kernel-modules
+kernel-modules-extra
+
+# The point of a live image is to install
+anaconda
+anaconda-install-env-deps
+anaconda-live
+@anaconda-tools
+# Anaconda has a weak dep on this and we don't want it on livecds, see
+# https://fedoraproject.org/wiki/Changes/RemoveDeviceMapperMultipathFromWorkstationLiveCD
+-fcoe-utils
+-sdubby
+
+# Need aajohan-comfortaa-fonts for the SVG rnotes images
+aajohan-comfortaa-fonts
+
+# Without this, initramfs generation during live image creation fails: #1242586
+dracut-live
+
+# anaconda needs the locales available to run for different locales
+glibc-all-langpacks
+
+# provide the livesys scripts
+livesys-scripts
+
+# Mandatory to build media with livemedia-creator
+memtest86+
+
+# libreoffice group
+@office-suite
+# firefox
+@internet-browser
+
+# KDE specific
+@dial-up
+@standard
+
+# install env-group to resolve RhBug:1891500
+@^kde-desktop-environment
+-kde-connect
+-kdeconnectd
+-kde-connect-libs
+
+@kde-apps
+@kde-media
+
+# drop tracker stuff pulled in by gtk3 (pagureio:fedora-kde/SIG#124)
+-tracker-miners
+-tracker
+
+# Additional packages that are not default in kde-* groups, but useful
+fuse
+
+# EPEL repo
+epel-release
+
+### space issues
+-ktorrent			# kget has also basic torrent features (~3 megs)
+-digikam			# digikam has duplicate functionality with gwenview (~28 megs)
+-kipi-plugins			# ~8 megs + drags in Marble
+-krusader			# ~4 megs
+-k3b				# ~15 megs
+
+# minimization
+-hplip
+
+# Add alsa-sof-firmware to all images PR #51
+alsa-sof-firmware
+# Official NVIDIA GPU Driver Stack
+almalinux-release-nvidia-driver
+
+%end


### PR DESCRIPTION
Added 12 new kickstart configurations to support both GNOME and KDE desktops for AlmaLinux 9, 10, and 10-kitten
  (available for  x86_64  and  aarch64  architectures):

  • AlmaLinux 9: GNOME/KDE ( x86_64 ,  aarch64 )
  • AlmaLinux 10: GNOME/KDE ( x86_64 ,  aarch64 )
  • AlmaLinux 10-Kitten: GNOME/KDE ( x86_64 ,  aarch64 )

  Key details inside the kickstarts:

  • Added the  almalinux-nvidia  repository pointing to the AlmaLinux CUDA repo.
  • Modified the  %post  script to install the driver packages ( nvidia-open ,  libva-nvidia-driver , and          
  almalinux-release-nvidia-driver  where applicable) inside the chroot environment.
  • Configured dynamic initramfs regeneration inside  %post  to bundle the NVIDIA kernel modules on the Live Media.
  ──────
  ## 🛠 Modifications & Enhancements

  ### 1. Build Script ( build-livemedia.sh )

  • Added a new  --with-nvidia  option.
  • Restricts NVIDIA driver installation only to supported versions (AlmaLinux 9+) and architectures (excludes     
  x86_64_v2 ).
  • Dynamically adjusts output paths, ISO names, and volume labels when  --with-nvidia  is enabled (adding  -NVIDIA
  suffixes).
  • Quality-of-life improvement: Automatically removes the previous build results directory if it already exists
  (previously,  livemedia-creator  would fail if the output directory wasn't manually deleted beforehand).

  ### 2. GitHub Actions workflows

  •  .github/actions/shared-steps/action.yml : Added the new  with_nvidia  input parameter, updated output
  directory paths, and passed the  --with-nvidia  flag to the build script.
  •  .github/workflows/build-media.yml : Added a  with_nvidia  boolean workflow input and conditionally skipped    
  x86_64_v2  architecture builds since NVIDIA drivers are not supported on it.

  ### 3. Documentation & Repository Configurations

  •  README.md : Updated documentation to detail NVIDIA GPU driver build support, explain the  --with-nvidia  flag,
  and list necessary local dependencies (such as enabling the  filelists  metadata option in DNF config).
  •  .gitignore : Added rule to exclude local  /results  directories from being tracked.
  ──────
  ## 🧪 Testing Verification

  • Built live media locally (Alma 10 amd64).
  • Booted generated amd64 Alma 10 KDE and Gnome ISO and confirmed Nvidia driver present and working.
  • Confirmed that output files are correctly structured with the  -NVIDIA  suffix.
  • Verified that  x86_64_v2  builds are properly excluded when  --with-nvidia  is set.
